### PR TITLE
Unmappable character for encoding US-ASCII

### DIFF
--- a/src/main/java/com/keyfactor/ejbca/client/enroll/EnrollGenKeysCommand.java
+++ b/src/main/java/com/keyfactor/ejbca/client/enroll/EnrollGenKeysCommand.java
@@ -65,7 +65,7 @@ public class EnrollGenKeysCommand extends EnrollCommandBase {
 	{
 		registerParameter(new Parameter(KEYALG_ARG, "cipher", MandatoryMode.MANDATORY, StandaloneMode.FORBID,
 				ParameterMode.ARGUMENT,
-				"Cipher – must be one of [ " + KeyTools.KEYALGORITHM_RSA + ", " + KeyTools.KEYALGORITHM_EC + ", "
+				"Cipher must be one of [ " + KeyTools.KEYALGORITHM_RSA + ", " + KeyTools.KEYALGORITHM_EC + ", "
 						+ KeyTools.KEYALGORITHM_ED25519 + ", " + KeyTools.KEYALGORITHM_ED448 + "]"));
 		StringBuilder ecCurvesFormatted = new StringBuilder();
 		ecCurvesFormatted.append("[");


### PR DESCRIPTION
Fix the error "unmappable character (0xE2) for encoding US-ASCII" when building on ubuntu:latest

To reproduce:

> docker run -it ubuntu:latest /bin/bash
ubuntu> apt update
ubuntu> apt install maven git -y
ubuntu> git clone https://github.com/Keyfactor/ejbca-easy-rest-client.git
ubuntu> cd ejbca-easy-rest-client
ubuntu> mvn clean package

ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /ejbca-easy-rest-client/src/main/java/com/keyfactor/ejbca/client/enroll/EnrollGenKeysCommand.java:[68,12] error: unmappable character (0xE2) for encoding US-ASCII
[ERROR] /ejbca-easy-rest-client/src/main/java/com/keyfactor/ejbca/client/enroll/EnrollGenKeysCommand.java:[68,13] error: unmappable character (0x80) for encoding US-ASCII
[ERROR] /ejbca-easy-rest-client/src/main/java/com/keyfactor/ejbca/client/enroll/EnrollGenKeysCommand.java:[68,14] error: unmappable character (0x93) for encoding US-ASCII
[INFO] 3 errors