### PR TITLE
feat: add custom subject dn and san to stress test. update error log …

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,197 @@ java -jar build/erce-1.0.0.jar enroll genkeys --authkeystore /opt/ejbca/p12/supe
 - v1/configdump
  
 ### Additional Commands
-- Stress Test
+
+#### X509 Stress Test
+
+The X509 stress test command performs multi-threaded certificate issuance testing against EJBCA to measure performance and throughput.
+
+**Basic Usage:**
+```bash
+java -jar build/erce-1.9.0.jar stress \
+  --authkeystore /path/to/admin.p12 \
+  --authkeystorepass password \
+  --hostname ejbca.example.com:8443 \
+  --ca "MyCA" \
+  --certificateprofile "ENDUSER" \
+  --endentityprofile "MyProfile" \
+  --threads 10 \
+  --certs 100
+```
+
+**Advanced Features:**
+
+*Custom Subject DN and SAN:*
+```bash
+java -jar build/erce-1.9.0.jar stress \
+  --authkeystore /path/to/admin.p12 \
+  --authkeystorepass password \
+  --hostname ejbca.example.com:8443 \
+  --ca "MyCA" \
+  --certificateprofile "ENDUSER" \
+  --endentityprofile "MyProfile" \
+  --threads 5 \
+  --certs 50 \
+  --subjectdn "CN=User,OU=Engineering,O=Keyfactor,C=US" \
+  --san "dnsName=user.example.com,ipAddress=10.0.0.1"
+```
+
+*Certificate History Testing (multiple certs per entity):*
+```bash
+java -jar build/erce-1.9.0.jar stress \
+  --authkeystore /path/to/admin.p12 \
+  --authkeystorepass password \
+  --hostname ejbca.example.com:8443 \
+  --ca "MyCA" \
+  --certificateprofile "ENDUSER" \
+  --endentityprofile "MyProfile" \
+  --threads 10 \
+  --certs 100 \
+  --history 2
+```
+
+*Revocation Testing:*
+```bash
+java -jar build/erce-1.9.0.jar stress \
+  --authkeystore /path/to/admin.p12 \
+  --authkeystorepass password \
+  --hostname ejbca.example.com:8443 \
+  --ca "MyCA" \
+  --certificateprofile "ENDUSER" \
+  --endentityprofile "MyProfile" \
+  --threads 10 \
+  --certs 100 \
+  --revoke \
+  --savecerts issued_certs.txt
+```
+
+*Bulk Revocation from File:*
+```bash
+java -jar build/erce-1.9.0.jar stress \
+  --authkeystore /path/to/admin.p12 \
+  --authkeystorepass password \
+  --hostname ejbca.example.com:8443 \
+  --revokefile issued_certs.txt \
+  --threads 10
+```
+
+*Progress Tracking and CSV Output:*
+```bash
+java -jar build/erce-1.9.0.jar stress \
+  --authkeystore /path/to/admin.p12 \
+  --authkeystorepass password \
+  --hostname ejbca.example.com:8443 \
+  --ca "MyCA" \
+  --certificateprofile "ENDUSER" \
+  --endentityprofile "MyProfile" \
+  --threads 10 \
+  --certs 100 \
+  --progressinterval 5 \
+  --outputformat csv \
+  --outputfile results.csv
+```
+
+#### OCSP Stress Test
+
+The OCSP stress test command performs multi-threaded OCSP status lookups to test OCSP responder performance.
+
+**Basic Usage:**
+```bash
+java -jar build/erce-1.9.0.jar ocspstress \
+  --ocspurl "http://ejbca.example.com:8080/ejbca/publicweb/status/ocsp" \
+  --ocspsnfile serial_numbers.txt \
+  --cacertfile ca.pem \
+  --threads 10 \
+  --waittime 50
+```
+
+**Serial Number File Formats:**
+
+Simple format (one serial per line):
+```
+12345678
+0xABCDEF123456
+987654321
+```
+
+Or use the pipe-delimited format from `--savecerts`:
+```
+1A2B3C4D5E6F|CN=Test CA,O=Keyfactor,C=US
+7G8H9I0J1K2L|CN=Test CA,O=Keyfactor,C=US
+```
+
+**Advanced Features:**
+
+*Time-Limited Test with Random Wait:*
+```bash
+java -jar build/erce-1.9.0.jar ocspstress \
+  --ocspurl "http://ejbca.example.com:8080/ocsp" \
+  --ocspsnfile serial_numbers.txt \
+  --cacertfile ca.pem \
+  --threads 20 \
+  --waittime 100 \
+  --duration 300 \
+  --randomwait
+```
+
+*GET Requests (instead of POST):*
+```bash
+java -jar build/erce-1.9.0.jar ocspstress \
+  --ocspurl "http://ejbca.example.com:8080/ocsp" \
+  --ocspsnfile serial_numbers.txt \
+  --cacertfile ca.pem \
+  --threads 5 \
+  --waittime 100 \
+  --reqtype GET
+```
+
+*Save Debug Requests and Responses:*
+```bash
+java -jar build/erce-1.9.0.jar ocspstress \
+  --ocspurl "http://ejbca.example.com:8080/ocsp" \
+  --ocspsnfile serial_numbers.txt \
+  --cacertfile ca.pem \
+  --threads 5 \
+  --waittime 100 \
+  --saveocsp /tmp/ocsp-debug
+```
+
+*Progress Tracking and Markdown Output:*
+```bash
+java -jar build/erce-1.9.0.jar ocspstress \
+  --ocspurl "http://ejbca.example.com:8080/ocsp" \
+  --ocspsnfile serial_numbers.txt \
+  --cacertfile ca.pem \
+  --threads 10 \
+  --waittime 50 \
+  --duration 60 \
+  --progressinterval 5 \
+  --outputformat markdown \
+  --outputfile results.md
+```
+
+**Integrated Workflow (X509 + OCSP):**
+```bash
+# Step 1: Issue certificates and save for OCSP testing
+java -jar build/erce-1.9.0.jar stress \
+  --authkeystore /path/to/admin.p12 \
+  --authkeystorepass password \
+  --hostname ejbca.example.com:8443 \
+  --ca "MyCA" \
+  --certificateprofile "ENDUSER" \
+  --endentityprofile "MyProfile" \
+  --threads 10 \
+  --certs 100 \
+  --savecerts issued_certs.txt
+
+# Step 2: Run OCSP stress test on issued certificates
+java -jar build/erce-1.9.0.jar ocspstress \
+  --ocspurl "http://ejbca.example.com:8080/ocsp" \
+  --ocspsnfile issued_certs.txt \
+  --cacertfile myca.pem \
+  --threads 10 \
+  --waittime 50
+```
 
 ## Community Support
 In the [Keyfactor Community](https://www.keyfactor.com/community/), we welcome contributions. 
@@ -65,5 +255,3 @@ See all [Keyfactor EJBCA GitHub projects](https://github.com/orgs/Keyfactor/repo
 
 ### On DockerHub
 See the [EJBCA container on DockerHub](https://hub.docker.com/r/keyfactor/ejbca-ce).
-
-TESTING

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,7 @@ tasks.jar {
 }
 
 group = "com.keyfactor"
-version = "1.9.0"
+version = "1.10.0"
 description = "Easy REST Client for EJBCA"
 java.sourceCompatibility = JavaVersion.VERSION_17
 

--- a/src/main/java/com/keyfactor/ejbca/client/stress/OcspStressTestCommand.java
+++ b/src/main/java/com/keyfactor/ejbca/client/stress/OcspStressTestCommand.java
@@ -15,17 +15,25 @@ package com.keyfactor.ejbca.client.stress;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.security.KeyStore;
+import java.security.PrivateKey;
 import java.security.SecureRandom;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,8 +63,13 @@ import org.bouncycastle.cert.ocsp.RevokedStatus;
 import org.bouncycastle.cert.ocsp.SingleResp;
 import org.bouncycastle.cert.ocsp.UnknownStatus;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.ContentVerifierProvider;
 import org.bouncycastle.operator.DigestCalculatorProvider;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+import org.bouncycastle.util.encoders.Base64;
 import org.ejbca.ui.cli.infrastructure.command.CommandResult;
 import org.ejbca.ui.cli.infrastructure.parameter.Parameter;
 import org.ejbca.ui.cli.infrastructure.parameter.ParameterContainer;
@@ -66,8 +79,6 @@ import org.ejbca.ui.cli.infrastructure.parameter.enums.StandaloneMode;
 
 import com.keyfactor.ejbca.client.ErceCommandBase;
 import com.keyfactor.util.CertTools;
-
-import org.ejbca.ui.cli.infrastructure.parameter.ParameterHandler;
 
 /**
  * A CLI command for performing OCSP stress testing.
@@ -97,10 +108,6 @@ public class OcspStressTestCommand extends ErceCommandBase {
     private static final String OUTPUT_FILE_ARG = "--outputfile";
     private static final String PROGRESS_INTERVAL_ARG = "--progressinterval";
 
-    // Base class parameter names (to override them as optional)
-    private static final String AUTH_KEYSTORE_ARG = "--authkeystore";
-    private static final String HOSTNAME_ARG = "--hostname";
-
     // Volatile flag to signal threads to stop
     private volatile boolean stopRequested = false;
 
@@ -111,7 +118,6 @@ public class OcspStressTestCommand extends ErceCommandBase {
 
     {
         // Register OCSP-specific parameters
-        // Note: --authkeystore and --hostname are inherited from base class but automatically injected
         registerParameter(new Parameter(OCSP_URL_ARG, "OCSP URL", MandatoryMode.MANDATORY, StandaloneMode.FORBID,
                 ParameterMode.ARGUMENT, "OCSP responder URL, e.g. http://myhost:8080/ejbca/publicweb/status/ocsp"));
         registerParameter(new Parameter(OCSP_SN_FILE_ARG, "Serial number file", MandatoryMode.MANDATORY,
@@ -159,12 +165,10 @@ public class OcspStressTestCommand extends ErceCommandBase {
      * Inner class to hold certificate information
      */
     private static class CertificateInfo {
-        String serialNumber;
-        String issuerDn;
+        private String serialNumber;
 
-        CertificateInfo(String serialNumber, String issuerDn) {
+        CertificateInfo(String serialNumber) {
             this.serialNumber = serialNumber;
-            this.issuerDn = issuerDn;
         }
     }
 
@@ -194,50 +198,6 @@ public class OcspStressTestCommand extends ErceCommandBase {
             this.statusCounts = new HashMap<>();
             this.responseTimes = new ArrayList<>();
         }
-    }
-
-    /**
-     * Override base class execute to automatically inject dummy authentication parameters
-     * since OCSP stress testing doesn't require keystore authentication
-     */
-    @Override
-    public CommandResult execute(String... arguments) {
-        // Inject dummy values for base class mandatory parameters if not provided
-        List<String> modifiedArgs = new ArrayList<>();
-        boolean hasAuthKeystore = false;
-        boolean hasHostname = false;
-
-        for (String arg : arguments) {
-            modifiedArgs.add(arg);
-            if (arg.equals(AUTH_KEYSTORE_ARG)) {
-                hasAuthKeystore = true;
-            } else if (arg.equals(HOSTNAME_ARG)) {
-                hasHostname = true;
-            }
-        }
-
-        // Add dummy values if not provided by user
-        if (!hasAuthKeystore) {
-            modifiedArgs.add(AUTH_KEYSTORE_ARG);
-            modifiedArgs.add("/dev/null");
-        }
-        if (!hasHostname) {
-            modifiedArgs.add(HOSTNAME_ARG);
-            modifiedArgs.add("localhost:8080");
-        }
-
-        ParameterContainer parameters = parameterHandler.parseParameters(
-            modifiedArgs.toArray(new String[0])
-        );
-        if (parameters == null) {
-            return CommandResult.CLI_FAILURE;
-        }
-        if (parameters.containsKey(ParameterHandler.HELP_KEY)) {
-            printManPage();
-            return CommandResult.SUCCESS;
-        }
-        // Skip the base class's keystore password validation - not needed for OCSP
-        return execute(parameters);
     }
 
     @Override
@@ -372,18 +332,18 @@ public class OcspStressTestCommand extends ErceCommandBase {
             log.error("Failed to load CA certificate from file: " + caCertFile);
             return CommandResult.CLI_FAILURE;
         }
-        log.info("Loaded CA certificate: " + caCert.getSubjectDN().toString());
+        log.info("Loaded CA certificate: " + caCert.getSubjectX500Principal().getName().toString());
 
         // Load signing credentials if provided
-        final java.security.PrivateKey signingKey;
+        final PrivateKey signingKey;
         final X509Certificate[] signingCertChain;
         if (ocspAuthStore != null && ocspAuthPasswd != null) {
             try {
                 Object[] credentials = loadSigningCredentials(ocspAuthStore, ocspAuthPasswd);
-                signingKey = (java.security.PrivateKey) credentials[0];
+                signingKey = (PrivateKey) credentials[0];
                 signingCertChain = (X509Certificate[]) credentials[1];
                 log.info("Loaded OCSP request signing credentials from: " + ocspAuthStore);
-                log.info("Signing certificate: " + signingCertChain[0].getSubjectDN().toString());
+                log.info("Signing certificate: " + signingCertChain[0].getSubjectX500Principal().getName().toString());
             } catch (Exception e) {
                 log.error("Failed to load signing credentials: " + e.getMessage());
                 return CommandResult.CLI_FAILURE;
@@ -447,7 +407,7 @@ public class OcspStressTestCommand extends ErceCommandBase {
 
         // Add shutdown hook to gracefully handle Ctrl+C
         Thread shutdownHook = new Thread(() -> {
-            System.out.println("\nShutdown signal received, stopping test and calculating statistics...");
+            log.info("\nShutdown signal received, stopping test and calculating statistics...");
             stopRequested = true;
 
             // Give threads a moment to finish current requests
@@ -540,7 +500,7 @@ public class OcspStressTestCommand extends ErceCommandBase {
                 // Use System.out for thread completion to ensure visibility during shutdown
                 String completionMsg = "Thread " + threadId + " completed " + requestCount + " requests";
                 if (stopRequested) {
-                    System.out.println(completionMsg);
+                	log.info(completionMsg);
                 } else {
                     log.info(completionMsg);
                 }
@@ -643,7 +603,7 @@ public class OcspStressTestCommand extends ErceCommandBase {
                     // Try pipe-delimited format first
                     if (line.contains("|")) {
                         String[] parts = line.split("\\|", 2);
-                        certs.add(new CertificateInfo(parts[0], parts[1]));
+                        certs.add(new CertificateInfo(parts[0]));
                     } else {
                         // Simple serial number format
                         BigInteger serialNumber;
@@ -657,7 +617,7 @@ public class OcspStressTestCommand extends ErceCommandBase {
                                 serialNumber = new BigInteger(line);
                             }
                         }
-                        certs.add(new CertificateInfo(serialNumber.toString(16).toUpperCase(), null));
+                        certs.add(new CertificateInfo(serialNumber.toString(16).toUpperCase()));
                     }
                 } catch (NumberFormatException e) {
                     log.warn("Skipping invalid serial number at line " + lineNumber + ": " + line);
@@ -696,30 +656,30 @@ public class OcspStressTestCommand extends ErceCommandBase {
      * Returns array: [0] = PrivateKey, [1] = X509Certificate[]
      */
     private Object[] loadSigningCredentials(String keystorePath, String password) throws Exception {
-        java.io.FileInputStream fis = null;
+        FileInputStream fis = null;
         try {
-            fis = new java.io.FileInputStream(keystorePath);
+            fis = new FileInputStream(keystorePath);
 
             // Try PKCS12 first
-            java.security.KeyStore keystore = null;
+            KeyStore keystore = null;
             try {
-                keystore = java.security.KeyStore.getInstance("PKCS12");
+                keystore = KeyStore.getInstance("PKCS12");
                 keystore.load(fis, password.toCharArray());
             } catch (Exception e) {
                 // If PKCS12 fails, try JKS
                 fis.close();
-                fis = new java.io.FileInputStream(keystorePath);
-                keystore = java.security.KeyStore.getInstance("JKS");
+                fis = new FileInputStream(keystorePath);
+                keystore = KeyStore.getInstance("JKS");
                 keystore.load(fis, password.toCharArray());
             }
 
             // Find the first private key entry
-            java.util.Enumeration<String> aliases = keystore.aliases();
+            Enumeration<String> aliases = keystore.aliases();
             while (aliases.hasMoreElements()) {
                 String alias = aliases.nextElement();
                 if (keystore.isKeyEntry(alias)) {
-                    java.security.PrivateKey privateKey = (java.security.PrivateKey) keystore.getKey(alias, password.toCharArray());
-                    java.security.cert.Certificate[] certChain = keystore.getCertificateChain(alias);
+                    PrivateKey privateKey = (PrivateKey) keystore.getKey(alias, password.toCharArray());
+                    Certificate[] certChain = keystore.getCertificateChain(alias);
 
                     if (privateKey != null && certChain != null && certChain.length > 0) {
                         // Convert to X509Certificate array
@@ -749,7 +709,7 @@ public class OcspStressTestCommand extends ErceCommandBase {
      * Optionally signs the request if signing credentials are provided
      */
     private OcspRequestWithNonce buildOcspRequest(BigInteger serialNumber, X509Certificate caCert, int nonceLength,
-            java.security.PrivateKey signingKey, X509Certificate[] signingCertChain)
+            PrivateKey signingKey, X509Certificate[] signingCertChain)
             throws Exception {
         // Create digest calculator
         DigestCalculatorProvider digCalcProv = new JcaDigestCalculatorProviderBuilder()
@@ -787,7 +747,7 @@ public class OcspStressTestCommand extends ErceCommandBase {
             }
 
             // Create content signer
-            org.bouncycastle.operator.ContentSigner signer = new org.bouncycastle.operator.jcajce.JcaContentSignerBuilder("SHA256withRSA")
+            ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
                     .setProvider(BouncyCastleProvider.PROVIDER_NAME)
                     .build(signingKey);
 
@@ -821,8 +781,8 @@ public class OcspStressTestCommand extends ErceCommandBase {
 
             case "GET":
                 // Encode OCSP request as Base64 per RFC 6960 Section A.1.1
-                byte[] base64Bytes = org.bouncycastle.util.encoders.Base64.encode(requestBytes);
-                String base64Req = new String(base64Bytes, java.nio.charset.StandardCharsets.US_ASCII);
+                byte[] base64Bytes = Base64.encode(requestBytes);
+                String base64Req = new String(base64Bytes, StandardCharsets.US_ASCII);
 
                 // EJBCA's OCSP servlet expects standard Base64 with URL encoding
                 // It uses URLDecoder.decode() then replaces spaces with '+' before Base64 decoding
@@ -909,16 +869,16 @@ public class OcspStressTestCommand extends ErceCommandBase {
     private boolean verifyOcspResponseSignature(BasicOCSPResp basicResp, X509Certificate caCert) {
         try {
             // Get certificates from OCSP response (OCSP responder certificate)
-            org.bouncycastle.cert.X509CertificateHolder[] certs = basicResp.getCerts();
+            X509CertificateHolder[] certs = basicResp.getCerts();
 
             if (certs != null && certs.length > 0) {
                 // OCSP response is signed by a delegated OCSP responder certificate
                 // Verify using the first certificate in the response (OCSP responder cert)
-                org.bouncycastle.cert.X509CertificateHolder responderCert = certs[0];
+                X509CertificateHolder responderCert = certs[0];
 
                 // Build content verifier using the OCSP responder's public key
-                org.bouncycastle.operator.ContentVerifierProvider verifierProvider =
-                    new org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder()
+                ContentVerifierProvider verifierProvider =
+                    new JcaContentVerifierProviderBuilder()
                         .setProvider(BouncyCastleProvider.PROVIDER_NAME)
                         .build(responderCert);
 
@@ -936,8 +896,8 @@ public class OcspStressTestCommand extends ErceCommandBase {
                 return true;
             } else {
                 // OCSP response is signed directly by the CA certificate
-                org.bouncycastle.operator.ContentVerifierProvider verifierProvider =
-                    new org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder()
+                ContentVerifierProvider verifierProvider =
+                    new JcaContentVerifierProviderBuilder()
                         .setProvider(BouncyCastleProvider.PROVIDER_NAME)
                         .build(caCert.getPublicKey());
 
@@ -1116,14 +1076,14 @@ public class OcspStressTestCommand extends ErceCommandBase {
         long successfulRequests = totalRequests - totalFailures;
         double executionTime = duration / 1000.0;
 
-        System.out.println();
-        System.out.println("===== OCSP Stress Test Results =====");
-        System.out.println("Total execution time: " + String.format("%.2f", executionTime) + " seconds");
-        System.out.println("Total requests: " + totalRequests);
-        System.out.println("Successful requests: " + successfulRequests);
-        System.out.println("Failed requests: " + totalFailures);
+        log.info("\n");
+        log.info("===== OCSP Stress Test Results =====\n");
+        log.info("Total execution time: " + String.format("%.2f", executionTime) + " seconds");
+        log.info("Total requests: " + totalRequests);
+        log.info("Successful requests: " + successfulRequests);
+        log.info("Failed requests: " + totalFailures + "\n");
         if (executionTime > 0) {
-            System.out.println("Throughput: " + String.format("%.2f", totalRequests / executionTime) + " requests/second");
+        	log.info("Throughput: " + String.format("%.2f", totalRequests / executionTime) + " requests/second");
         }
 
         // Response time statistics
@@ -1136,25 +1096,25 @@ public class OcspStressTestCommand extends ErceCommandBase {
             long p95Time = allResponseTimes.get((int) (allResponseTimes.size() * 0.95));
             long p99Time = allResponseTimes.get((int) (allResponseTimes.size() * 0.99));
 
-            System.out.println();
-            System.out.println("Response Times (ms):");
-            System.out.println("  Min: " + minTime);
-            System.out.println("  Max: " + maxTime);
-            System.out.println("  Avg: " + avgTime);
-            System.out.println("  P50: " + p50Time);
-            System.out.println("  P95: " + p95Time);
-            System.out.println("  P99: " + p99Time);
+            log.info("\n");
+            log.info("Response Times (ms):"+ "\n");
+            log.info("  Min: " + minTime + "\n");
+            log.info("  Max: " + maxTime + "\n");
+            log.info("  Avg: " + avgTime + "\n");
+            log.info("  P50: " + p50Time + "\n");
+            log.info("  P95: " + p95Time + "\n");
+            log.info("  P99: " + p99Time + "\n");
         }
 
         // Certificate status breakdown
         if (!totalStatusCounts.isEmpty()) {
-            System.out.println();
-            System.out.println("Certificate Status Distribution:");
+            log.info("\n");
+            log.info("Certificate Status Distribution:" + "\n");
             for (Map.Entry<String, Integer> entry : totalStatusCounts.entrySet()) {
-                System.out.println("  " + entry.getKey() + ": " + entry.getValue());
+                log.info("  " + entry.getKey() + ": " + entry.getValue() + "\n");
             }
         }
-        System.out.println();
+        log.info("\n");
     }
 
     /**
@@ -1204,7 +1164,7 @@ public class OcspStressTestCommand extends ErceCommandBase {
             writer.println("Test Duration (s),Total Requests,Successful,Failed,Throughput (req/s),Min Response (ms),Max Response (ms),Avg Response (ms),P50 (ms),P95 (ms),P99 (ms),GOOD,REVOKED,UNKNOWN,Timestamp");
 
             // Write data row
-            String timestamp = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
+            String timestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
             writer.println(String.format("%.2f,%d,%d,%d,%.2f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%s",
                     executionTime, totalRequests, successfulRequests, totalFailures, throughput,
                     minTime, maxTime, avgTime, p50Time, p95Time, p99Time,
@@ -1254,7 +1214,7 @@ public class OcspStressTestCommand extends ErceCommandBase {
         int revokedCount = totalStatusCounts.getOrDefault("REVOKED", 0);
         int unknownCount = totalStatusCounts.getOrDefault("UNKNOWN", 0);
 
-        String timestamp = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
+        String timestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
 
         try (PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(filename)))) {
             writer.println("# OCSP Stress Test Results");

--- a/src/main/java/com/keyfactor/ejbca/client/stress/OcspStressTestCommand.java
+++ b/src/main/java/com/keyfactor/ejbca/client/stress/OcspStressTestCommand.java
@@ -1,0 +1,1331 @@
+/*************************************************************************
+ *                                                                       *
+ *  Keyfactor Community                                                  *
+ *                                                                       *
+ *  This software is free software; you can redistribute it and/or       *
+ *  modify it under the terms of the GNU Lesser General Public           *
+ *  License as published by the Free Software Foundation; either         *
+ *  version 2.1 of the License, or any later version.                    *
+ *                                                                       *
+ *  See terms of license at gnu.org.                                     *
+ *                                                                       *
+ *************************************************************************/
+package com.keyfactor.ejbca.client.stress;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.security.SecureRandom;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.log4j.Logger;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.ocsp.OCSPObjectIdentifiers;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.ocsp.BasicOCSPResp;
+import org.bouncycastle.cert.ocsp.CertificateID;
+import org.bouncycastle.cert.ocsp.OCSPReq;
+import org.bouncycastle.cert.ocsp.OCSPReqBuilder;
+import org.bouncycastle.cert.ocsp.OCSPResp;
+import org.bouncycastle.cert.ocsp.RevokedStatus;
+import org.bouncycastle.cert.ocsp.SingleResp;
+import org.bouncycastle.cert.ocsp.UnknownStatus;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.DigestCalculatorProvider;
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+import org.ejbca.ui.cli.infrastructure.command.CommandResult;
+import org.ejbca.ui.cli.infrastructure.parameter.Parameter;
+import org.ejbca.ui.cli.infrastructure.parameter.ParameterContainer;
+import org.ejbca.ui.cli.infrastructure.parameter.enums.MandatoryMode;
+import org.ejbca.ui.cli.infrastructure.parameter.enums.ParameterMode;
+import org.ejbca.ui.cli.infrastructure.parameter.enums.StandaloneMode;
+
+import com.keyfactor.ejbca.client.ErceCommandBase;
+import com.keyfactor.util.CertTools;
+
+import org.ejbca.ui.cli.infrastructure.parameter.ParameterHandler;
+
+/**
+ * A CLI command for performing OCSP stress testing.
+ * Sends multi-threaded OCSP requests to test OCSP responder performance.
+ *
+ * NOTE: This command overrides the base class to make --authkeystore and --hostname optional
+ * since OCSP stress testing can work against HTTP endpoints without authentication.
+ */
+public class OcspStressTestCommand extends ErceCommandBase {
+
+    private static final Logger log = Logger.getLogger(OcspStressTestCommand.class);
+
+    private static final String OCSP_URL_ARG = "--ocspurl";
+    private static final String OCSP_SN_FILE_ARG = "--ocspsnfile";
+    private static final String CA_CERT_FILE_ARG = "--cacertfile";
+    private static final String THREADS_ARG = "--threads";
+    private static final String WAIT_TIME_ARG = "--waittime";
+    private static final String REQ_TYPE_ARG = "--reqtype";
+    private static final String NONCE_LEN_ARG = "--ocspnoncelen";
+    private static final String DURATION_ARG = "--duration";
+    private static final String RANDOM_WAIT_ARG = "--randomwait";
+    private static final String VERIFY_NONCE_ARG = "--verifynonce";
+    private static final String OCSP_AUTH_STORE_ARG = "--ocspauthstore";
+    private static final String OCSP_AUTH_PASSWD_ARG = "--ocspauthpasswd";
+    private static final String SAVE_OCSP_ARG = "--saveocsp";
+    private static final String OUTPUT_FORMAT_ARG = "--outputformat";
+    private static final String OUTPUT_FILE_ARG = "--outputfile";
+    private static final String PROGRESS_INTERVAL_ARG = "--progressinterval";
+
+    // Base class parameter names (to override them as optional)
+    private static final String AUTH_KEYSTORE_ARG = "--authkeystore";
+    private static final String HOSTNAME_ARG = "--hostname";
+
+    // Volatile flag to signal threads to stop
+    private volatile boolean stopRequested = false;
+
+    // Volatile counters for real-time progress tracking
+    private volatile long totalRequestsCompleted = 0;
+    private volatile long totalSuccessfulRequests = 0;
+    private volatile long totalFailedRequests = 0;
+
+    {
+        // Register OCSP-specific parameters
+        // Note: --authkeystore and --hostname are inherited from base class but automatically injected
+        registerParameter(new Parameter(OCSP_URL_ARG, "OCSP URL", MandatoryMode.MANDATORY, StandaloneMode.FORBID,
+                ParameterMode.ARGUMENT, "OCSP responder URL, e.g. http://myhost:8080/ejbca/publicweb/status/ocsp"));
+        registerParameter(new Parameter(OCSP_SN_FILE_ARG, "Serial number file", MandatoryMode.MANDATORY,
+                StandaloneMode.FORBID, ParameterMode.ARGUMENT,
+                "Certificate serial number file. Either simple list (one per line) or pipe-delimited format from --savecerts"));
+        registerParameter(new Parameter(CA_CERT_FILE_ARG, "CA certificate file", MandatoryMode.MANDATORY,
+                StandaloneMode.FORBID, ParameterMode.ARGUMENT, "PEM-encoded CA certificate file"));
+        registerParameter(new Parameter(THREADS_ARG, "Number of threads", MandatoryMode.MANDATORY,
+                StandaloneMode.FORBID, ParameterMode.ARGUMENT, "Number of concurrent threads"));
+        registerParameter(new Parameter(WAIT_TIME_ARG, "Wait time (ms)", MandatoryMode.MANDATORY,
+                StandaloneMode.FORBID, ParameterMode.ARGUMENT, "Milliseconds to wait between requests per thread"));
+        registerParameter(new Parameter(REQ_TYPE_ARG, "Request type", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+                ParameterMode.ARGUMENT,
+                "OCSP request method. Options:\n" +
+                "  POST (default) - Standard OCSP POST request with Content-Type: application/ocsp-request\n" +
+                "  GET - OCSP GET request with Base64-encoded request in URL path\n" +
+                "Default: POST\n" +
+                "Note: RFC 6960 Section A.1 recommends that GET requests longer than 255 bytes\n" +
+                "after encoding SHOULD use POST instead. Signed OCSP requests are typically much\n" +
+                "larger than unsigned requests and may exceed this limit."));
+        registerParameter(new Parameter(NONCE_LEN_ARG, "Nonce length", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+                ParameterMode.ARGUMENT, "Nonce length in bytes. Default: 32. Set to 0 to disable nonce"));
+        registerParameter(new Parameter(DURATION_ARG, "Duration (seconds)", MandatoryMode.OPTIONAL,
+                StandaloneMode.FORBID, ParameterMode.ARGUMENT,
+                "Test duration in seconds. Default: run indefinitely until interrupted"));
+        registerParameter(new Parameter(RANDOM_WAIT_ARG, "", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+                ParameterMode.FLAG, "Use random wait time between 0 and --waittime ms"));
+        registerParameter(new Parameter(VERIFY_NONCE_ARG, "", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+                ParameterMode.FLAG, "Verify that OCSP response nonce matches request nonce. Only applicable when nonce is enabled"));
+        registerParameter(new Parameter(OCSP_AUTH_STORE_ARG, "Keystore file", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+                ParameterMode.ARGUMENT, "Keystore file (P12/JKS) containing private key and certificate for signing OCSP requests"));
+        registerParameter(new Parameter(OCSP_AUTH_PASSWD_ARG, "Keystore password", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+                ParameterMode.ARGUMENT, "Password for the OCSP request signing keystore"));
+        registerParameter(new Parameter(SAVE_OCSP_ARG, "Directory path", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+                ParameterMode.ARGUMENT, "Directory path to save OCSP requests and responses for debugging (e.g., ./ocsp-debug)"));
+        registerParameter(new Parameter(OUTPUT_FORMAT_ARG, "Output format", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+                ParameterMode.ARGUMENT, "Output format for test results. Options: 'console' (default), 'csv', 'markdown'. When csv or markdown is specified, --outputfile is required."));
+        registerParameter(new Parameter(OUTPUT_FILE_ARG, "Output file", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+                ParameterMode.ARGUMENT, "File path to save test results in CSV or Markdown format. Required when --outputformat is csv or markdown."));
+        registerParameter(new Parameter(PROGRESS_INTERVAL_ARG, "Progress interval (seconds)", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+                ParameterMode.ARGUMENT, "Interval in seconds for displaying real-time progress updates. Default: 5 seconds. Set to 0 to disable progress updates."));
+    }
+
+    /**
+     * Inner class to hold certificate information
+     */
+    private static class CertificateInfo {
+        String serialNumber;
+        String issuerDn;
+
+        CertificateInfo(String serialNumber, String issuerDn) {
+            this.serialNumber = serialNumber;
+            this.issuerDn = issuerDn;
+        }
+    }
+
+    /**
+     * Inner class to hold OCSP request with nonce
+     */
+    private static class OcspRequestWithNonce {
+        OCSPReq request;
+        byte[] nonce;
+
+        OcspRequestWithNonce(OCSPReq request, byte[] nonce) {
+            this.request = request;
+            this.nonce = nonce;
+        }
+    }
+
+    /**
+     * Inner class to hold test results from each thread
+     */
+    private static class OcspTestResult {
+        List<String> failures;
+        Map<String, Integer> statusCounts;
+        List<Long> responseTimes;
+
+        OcspTestResult() {
+            this.failures = new ArrayList<>();
+            this.statusCounts = new HashMap<>();
+            this.responseTimes = new ArrayList<>();
+        }
+    }
+
+    /**
+     * Override base class execute to automatically inject dummy authentication parameters
+     * since OCSP stress testing doesn't require keystore authentication
+     */
+    @Override
+    public CommandResult execute(String... arguments) {
+        // Inject dummy values for base class mandatory parameters if not provided
+        List<String> modifiedArgs = new ArrayList<>();
+        boolean hasAuthKeystore = false;
+        boolean hasHostname = false;
+
+        for (String arg : arguments) {
+            modifiedArgs.add(arg);
+            if (arg.equals(AUTH_KEYSTORE_ARG)) {
+                hasAuthKeystore = true;
+            } else if (arg.equals(HOSTNAME_ARG)) {
+                hasHostname = true;
+            }
+        }
+
+        // Add dummy values if not provided by user
+        if (!hasAuthKeystore) {
+            modifiedArgs.add(AUTH_KEYSTORE_ARG);
+            modifiedArgs.add("/dev/null");
+        }
+        if (!hasHostname) {
+            modifiedArgs.add(HOSTNAME_ARG);
+            modifiedArgs.add("localhost:8080");
+        }
+
+        ParameterContainer parameters = parameterHandler.parseParameters(
+            modifiedArgs.toArray(new String[0])
+        );
+        if (parameters == null) {
+            return CommandResult.CLI_FAILURE;
+        }
+        if (parameters.containsKey(ParameterHandler.HELP_KEY)) {
+            printManPage();
+            return CommandResult.SUCCESS;
+        }
+        // Skip the base class's keystore password validation - not needed for OCSP
+        return execute(parameters);
+    }
+
+    @Override
+    protected CommandResult execute(ParameterContainer parameters) {
+        final String ocspUrl = parameters.get(OCSP_URL_ARG);
+        final String serialNumberFile = parameters.get(OCSP_SN_FILE_ARG);
+        final String caCertFile = parameters.get(CA_CERT_FILE_ARG);
+        final String reqType = parameters.get(REQ_TYPE_ARG) != null ? parameters.get(REQ_TYPE_ARG) : "POST";
+
+        final int numberOfThreads;
+        try {
+            numberOfThreads = Integer.parseInt(parameters.get(THREADS_ARG));
+        } catch (NumberFormatException e) {
+            log.error(THREADS_ARG + " was not a numeric value");
+            return CommandResult.CLI_FAILURE;
+        }
+        if (numberOfThreads < 1) {
+            log.error(THREADS_ARG + " must be a positive value");
+            return CommandResult.CLI_FAILURE;
+        }
+
+        final int waitTime;
+        try {
+            waitTime = Integer.parseInt(parameters.get(WAIT_TIME_ARG));
+        } catch (NumberFormatException e) {
+            log.error(WAIT_TIME_ARG + " was not a numeric value");
+            return CommandResult.CLI_FAILURE;
+        }
+        if (waitTime < 0) {
+            log.error(WAIT_TIME_ARG + " must be non-negative");
+            return CommandResult.CLI_FAILURE;
+        }
+
+        final int nonceLength;
+        if (parameters.get(NONCE_LEN_ARG) != null) {
+            try {
+                nonceLength = Integer.parseInt(parameters.get(NONCE_LEN_ARG));
+            } catch (NumberFormatException e) {
+                log.error(NONCE_LEN_ARG + " was not a numeric value");
+                return CommandResult.CLI_FAILURE;
+            }
+        } else {
+            nonceLength = 32;
+        }
+
+        final boolean verifyNonce = parameters.containsKey(VERIFY_NONCE_ARG);
+
+        final long duration;
+        if (parameters.get(DURATION_ARG) != null) {
+            try {
+                duration = Long.parseLong(parameters.get(DURATION_ARG)) * 1000L; // Convert to ms
+            } catch (NumberFormatException e) {
+                log.error(DURATION_ARG + " was not a numeric value");
+                return CommandResult.CLI_FAILURE;
+            }
+        } else {
+            duration = Long.MAX_VALUE; // Run indefinitely
+        }
+
+        final boolean randomWait = parameters.containsKey(RANDOM_WAIT_ARG);
+
+        // Parse OCSP request signing parameters
+        final String ocspAuthStore = parameters.get(OCSP_AUTH_STORE_ARG);
+        final String ocspAuthPasswd = parameters.get(OCSP_AUTH_PASSWD_ARG);
+
+        // Validate: if one is provided, both must be provided
+        if ((ocspAuthStore != null && ocspAuthPasswd == null) || (ocspAuthStore == null && ocspAuthPasswd != null)) {
+            log.error("Both " + OCSP_AUTH_STORE_ARG + " and " + OCSP_AUTH_PASSWD_ARG + " must be specified together for request signing");
+            return CommandResult.CLI_FAILURE;
+        }
+
+        // Parse save OCSP debug files parameter
+        final String saveOcspDir = parameters.get(SAVE_OCSP_ARG);
+        if (saveOcspDir != null) {
+            File dir = new File(saveOcspDir);
+            if (!dir.exists()) {
+                if (!dir.mkdirs()) {
+                    log.error("Failed to create directory: " + saveOcspDir);
+                    return CommandResult.CLI_FAILURE;
+                }
+                log.info("Created directory for OCSP debug files: " + saveOcspDir);
+            } else if (!dir.isDirectory()) {
+                log.error("Path exists but is not a directory: " + saveOcspDir);
+                return CommandResult.CLI_FAILURE;
+            }
+        }
+
+        // Parse output format parameters
+        final String outputFormat = parameters.get(OUTPUT_FORMAT_ARG) != null ? parameters.get(OUTPUT_FORMAT_ARG) : "console";
+        final String outputFile = parameters.get(OUTPUT_FILE_ARG);
+
+        // Validate output format
+        if (!outputFormat.equals("console") && !outputFormat.equals("csv") && !outputFormat.equals("markdown")) {
+            log.error("Invalid output format: " + outputFormat + ". Must be 'console', 'csv', or 'markdown'");
+            return CommandResult.CLI_FAILURE;
+        }
+
+        // Validate that outputFile is provided if format is csv or markdown
+        if ((outputFormat.equals("csv") || outputFormat.equals("markdown")) && outputFile == null) {
+            log.error("--outputfile is required when --outputformat is '" + outputFormat + "'");
+            return CommandResult.CLI_FAILURE;
+        }
+
+        // Parse progress interval
+        final int progressInterval;
+        if (parameters.get(PROGRESS_INTERVAL_ARG) != null) {
+            try {
+                progressInterval = Integer.parseInt(parameters.get(PROGRESS_INTERVAL_ARG));
+            } catch (NumberFormatException e) {
+                log.error(PROGRESS_INTERVAL_ARG + " was not a numeric value");
+                return CommandResult.CLI_FAILURE;
+            }
+            if (progressInterval < 0) {
+                log.error(PROGRESS_INTERVAL_ARG + " must be non-negative");
+                return CommandResult.CLI_FAILURE;
+            }
+        } else {
+            progressInterval = 5; // Default: 5 seconds
+        }
+
+        // Load certificate serial numbers
+        List<CertificateInfo> certList = loadCertificateInfo(serialNumberFile);
+        if (certList == null || certList.isEmpty()) {
+            log.error("No certificate serial numbers loaded from file: " + serialNumberFile);
+            return CommandResult.CLI_FAILURE;
+        }
+        log.info("Loaded " + certList.size() + " certificate serial numbers");
+
+        // Load CA certificate
+        X509Certificate caCert = loadCaCertificate(caCertFile);
+        if (caCert == null) {
+            log.error("Failed to load CA certificate from file: " + caCertFile);
+            return CommandResult.CLI_FAILURE;
+        }
+        log.info("Loaded CA certificate: " + caCert.getSubjectDN().toString());
+
+        // Load signing credentials if provided
+        final java.security.PrivateKey signingKey;
+        final X509Certificate[] signingCertChain;
+        if (ocspAuthStore != null && ocspAuthPasswd != null) {
+            try {
+                Object[] credentials = loadSigningCredentials(ocspAuthStore, ocspAuthPasswd);
+                signingKey = (java.security.PrivateKey) credentials[0];
+                signingCertChain = (X509Certificate[]) credentials[1];
+                log.info("Loaded OCSP request signing credentials from: " + ocspAuthStore);
+                log.info("Signing certificate: " + signingCertChain[0].getSubjectDN().toString());
+            } catch (Exception e) {
+                log.error("Failed to load signing credentials: " + e.getMessage());
+                return CommandResult.CLI_FAILURE;
+            }
+        } else {
+            signingKey = null;
+            signingCertChain = null;
+        }
+
+        // Start the stress test
+        log.info("Starting OCSP stress test with " + numberOfThreads + " threads");
+        log.info("OCSP URL: " + ocspUrl);
+        log.info("Request type: " + reqType);
+        log.info("Wait time: " + waitTime + " ms" + (randomWait ? " (random)" : ""));
+        log.info("Duration: " + (duration == Long.MAX_VALUE ? "unlimited" : (duration / 1000) + " seconds"));
+
+        long startTime = System.currentTimeMillis();
+        final List<CompletableFuture<OcspTestResult>> futures = new ArrayList<>();
+        Random random = new Random();
+
+        // Reset counters
+        totalRequestsCompleted = 0;
+        totalSuccessfulRequests = 0;
+        totalFailedRequests = 0;
+
+        // Start progress tracking thread if enabled
+        Thread progressThread = null;
+        if (progressInterval > 0) {
+            progressThread = new Thread(() -> {
+                long lastCompleted = 0;
+                long lastTime = System.currentTimeMillis();
+
+                while (!stopRequested) {
+                    try {
+                        Thread.sleep(progressInterval * 1000L);
+
+                        if (stopRequested) {
+                            break;
+                        }
+
+                        long currentTime = System.currentTimeMillis();
+                        long currentCompleted = totalRequestsCompleted;
+                        long intervalRequests = currentCompleted - lastCompleted;
+                        double intervalSeconds = (currentTime - lastTime) / 1000.0;
+                        double requestsPerSec = intervalSeconds > 0 ? intervalRequests / intervalSeconds : 0;
+
+                        System.out.println(String.format("Progress: %d requests (%d successful, %d failed) - %.2f req/s",
+                                currentCompleted, totalSuccessfulRequests, totalFailedRequests, requestsPerSec));
+
+                        lastCompleted = currentCompleted;
+                        lastTime = currentTime;
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            });
+            progressThread.setDaemon(true);
+            progressThread.start();
+        }
+
+        // Add shutdown hook to gracefully handle Ctrl+C
+        Thread shutdownHook = new Thread(() -> {
+            System.out.println("\nShutdown signal received, stopping test and calculating statistics...");
+            stopRequested = true;
+
+            // Give threads a moment to finish current requests
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException ignored) {
+            }
+
+            // Collect and report statistics
+            long endTime = System.currentTimeMillis();
+            long actualDuration = endTime - startTime;
+
+            List<OcspTestResult> results = new ArrayList<>();
+            for (CompletableFuture<OcspTestResult> future : futures) {
+                try {
+                    results.add(future.getNow(new OcspTestResult()));
+                } catch (Exception e) {
+                    // Ignore
+                }
+            }
+
+            reportStatisticsToConsole(results, actualDuration);
+        });
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+
+        // Launch threads
+        for (int threadNumber = 0; threadNumber < numberOfThreads; threadNumber++) {
+            final int threadId = threadNumber;
+
+            futures.add(CompletableFuture.supplyAsync(() -> {
+                OcspTestResult result = new OcspTestResult();
+                int requestCount = 0;
+
+                while (shouldContinue(startTime, duration)) {
+                    // Randomly select a certificate
+                    CertificateInfo cert = certList.get(random.nextInt(certList.size()));
+
+                    long requestStart = System.currentTimeMillis();
+                    try {
+                        // Build OCSP request
+                        OcspRequestWithNonce requestWithNonce = buildOcspRequest(new BigInteger(cert.serialNumber, 16), caCert,
+                                nonceLength, signingKey, signingCertChain);
+
+                        // Save debug request if enabled
+                        saveDebugRequest(requestWithNonce.request, saveOcspDir, threadId, requestCount);
+
+                        // Send request
+                        String status = sendOcspRequest(requestWithNonce.request, ocspUrl, reqType, caCert, requestWithNonce.nonce, verifyNonce, saveOcspDir, threadId, requestCount);
+                        result.statusCounts.merge(status, 1, Integer::sum);
+
+                        long responseTime = System.currentTimeMillis() - requestStart;
+                        result.responseTimes.add(responseTime);
+
+                        // Increment success counter
+                        synchronized (OcspStressTestCommand.this) {
+                            totalSuccessfulRequests++;
+                        }
+
+                    } catch (Exception e) {
+                        String errorMsg = "Thread " + threadId + " - OCSP request failed for SN "
+                                + cert.serialNumber + ": " + e.getMessage();
+                        result.failures.add(errorMsg);
+                        log.error(errorMsg);
+
+                        // Increment failure counter
+                        synchronized (OcspStressTestCommand.this) {
+                            totalFailedRequests++;
+                        }
+                    }
+
+                    // Increment total completed counter
+                    synchronized (OcspStressTestCommand.this) {
+                        totalRequestsCompleted++;
+                    }
+
+                    requestCount++;
+
+                    // Wait between requests
+                    if (waitTime > 0) {
+                        try {
+                            int actualWait = randomWait ? random.nextInt(waitTime + 1) : waitTime;
+                            Thread.sleep(actualWait);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            break;
+                        }
+                    }
+                }
+
+                // Use System.out for thread completion to ensure visibility during shutdown
+                String completionMsg = "Thread " + threadId + " completed " + requestCount + " requests";
+                if (stopRequested) {
+                    System.out.println(completionMsg);
+                } else {
+                    log.info(completionMsg);
+                }
+                return result;
+            }));
+        }
+
+        // Wait for all threads to complete
+        CompletableFuture<Void> allFutures = CompletableFuture
+                .allOf(futures.toArray(new CompletableFuture<?>[0]));
+
+        try {
+            allFutures.get();
+        } catch (InterruptedException e) {
+            log.info("\nTest interrupted, waiting for threads to finish...");
+            stopRequested = true;
+            // Wait a bit for threads to notice the stop flag
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        } catch (ExecutionException e) {
+            log.error("Thread execution error: " + e.getMessage());
+        }
+
+        long endTime = System.currentTimeMillis();
+        long actualDuration = endTime - startTime;
+
+        // Remove shutdown hook since we completed normally
+        try {
+            Runtime.getRuntime().removeShutdownHook(shutdownHook);
+        } catch (IllegalStateException e) {
+            // Shutdown already in progress, hook will handle statistics
+            return CommandResult.SUCCESS;
+        }
+
+        // Collect results from all threads (even if interrupted)
+        List<OcspTestResult> results = new ArrayList<>();
+        for (CompletableFuture<OcspTestResult> future : futures) {
+            try {
+                // Use a short timeout to get whatever results are available
+                results.add(future.getNow(new OcspTestResult()));
+            } catch (Exception e) {
+                log.error("Failed to get thread result: " + e.getMessage());
+            }
+        }
+
+        // Report statistics
+        reportStatistics(results, actualDuration);
+
+        // Write results to file if requested
+        if (outputFormat.equals("csv")) {
+            try {
+                writeResultsToCsv(outputFile, results, actualDuration);
+                log.info("Results saved to " + outputFile);
+            } catch (IOException e) {
+                log.error("Failed to write CSV results to file: " + e.getMessage());
+                return CommandResult.CLI_FAILURE;
+            }
+        } else if (outputFormat.equals("markdown")) {
+            try {
+                writeResultsToMarkdown(outputFile, results, actualDuration);
+                log.info("Results saved to " + outputFile);
+            } catch (IOException e) {
+                log.error("Failed to write Markdown results to file: " + e.getMessage());
+                return CommandResult.CLI_FAILURE;
+            }
+        }
+
+        return CommandResult.SUCCESS;
+    }
+
+    /**
+     * Check if the test should continue based on duration
+     */
+    private boolean shouldContinue(long startTime, long duration) {
+        return !stopRequested && (System.currentTimeMillis() - startTime) < duration;
+    }
+
+    /**
+     * Load certificate serial numbers from file
+     * Supports two formats:
+     * 1. Simple list: one serial number per line (decimal or hex with 0x prefix)
+     * 2. Pipe-delimited: serialNumber|issuerDn (from --savecerts)
+     */
+    private List<CertificateInfo> loadCertificateInfo(String filename) {
+        List<CertificateInfo> certs = new ArrayList<>();
+        int lineNumber = 0;
+        try (BufferedReader reader = new BufferedReader(new FileReader(filename))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                line = line.trim();
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+
+                try {
+                    // Try pipe-delimited format first
+                    if (line.contains("|")) {
+                        String[] parts = line.split("\\|", 2);
+                        certs.add(new CertificateInfo(parts[0], parts[1]));
+                    } else {
+                        // Simple serial number format
+                        BigInteger serialNumber;
+                        if (line.startsWith("0x") || line.startsWith("0X")) {
+                            serialNumber = new BigInteger(line.substring(2), 16);
+                        } else {
+                            try {
+                                serialNumber = new BigInteger(line, 16);
+                            } catch (NumberFormatException e) {
+                                // Try decimal format
+                                serialNumber = new BigInteger(line);
+                            }
+                        }
+                        certs.add(new CertificateInfo(serialNumber.toString(16).toUpperCase(), null));
+                    }
+                } catch (NumberFormatException e) {
+                    log.warn("Skipping invalid serial number at line " + lineNumber + ": " + line);
+                    continue;
+                }
+            }
+        } catch (IOException e) {
+            log.error("Failed to load certificate info: " + e.getMessage());
+            return null;
+        }
+        return certs;
+    }
+
+    /**
+     * Load CA certificate from PEM file
+     */
+    private X509Certificate loadCaCertificate(String filename) {
+        try {
+            List<X509Certificate> certs = CertTools.getCertsFromPEM(filename, X509Certificate.class);
+            if (certs.isEmpty()) {
+                log.error("No certificates found in CA certificate file");
+                return null;
+            }
+            return certs.get(0);
+        } catch (CertificateParsingException e) {
+            log.error("Failed to parse CA certificate: " + e.getMessage());
+            return null;
+        } catch (Exception e) {
+            log.error("Failed to load CA certificate: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Load signing credentials from keystore (P12 or JKS)
+     * Returns array: [0] = PrivateKey, [1] = X509Certificate[]
+     */
+    private Object[] loadSigningCredentials(String keystorePath, String password) throws Exception {
+        java.io.FileInputStream fis = null;
+        try {
+            fis = new java.io.FileInputStream(keystorePath);
+
+            // Try PKCS12 first
+            java.security.KeyStore keystore = null;
+            try {
+                keystore = java.security.KeyStore.getInstance("PKCS12");
+                keystore.load(fis, password.toCharArray());
+            } catch (Exception e) {
+                // If PKCS12 fails, try JKS
+                fis.close();
+                fis = new java.io.FileInputStream(keystorePath);
+                keystore = java.security.KeyStore.getInstance("JKS");
+                keystore.load(fis, password.toCharArray());
+            }
+
+            // Find the first private key entry
+            java.util.Enumeration<String> aliases = keystore.aliases();
+            while (aliases.hasMoreElements()) {
+                String alias = aliases.nextElement();
+                if (keystore.isKeyEntry(alias)) {
+                    java.security.PrivateKey privateKey = (java.security.PrivateKey) keystore.getKey(alias, password.toCharArray());
+                    java.security.cert.Certificate[] certChain = keystore.getCertificateChain(alias);
+
+                    if (privateKey != null && certChain != null && certChain.length > 0) {
+                        // Convert to X509Certificate array
+                        X509Certificate[] x509Chain = new X509Certificate[certChain.length];
+                        for (int i = 0; i < certChain.length; i++) {
+                            x509Chain[i] = (X509Certificate) certChain[i];
+                        }
+                        return new Object[] { privateKey, x509Chain };
+                    }
+                }
+            }
+
+            throw new Exception("No private key entry found in keystore");
+        } finally {
+            if (fis != null) {
+                try {
+                    fis.close();
+                } catch (Exception ignored) {
+                }
+            }
+        }
+    }
+
+    /**
+     * Build OCSP request for a certificate serial number
+     * Returns OcspRequestWithNonce containing both the request and the nonce (if used)
+     * Optionally signs the request if signing credentials are provided
+     */
+    private OcspRequestWithNonce buildOcspRequest(BigInteger serialNumber, X509Certificate caCert, int nonceLength,
+            java.security.PrivateKey signingKey, X509Certificate[] signingCertChain)
+            throws Exception {
+        // Create digest calculator
+        DigestCalculatorProvider digCalcProv = new JcaDigestCalculatorProviderBuilder()
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME).build();
+
+        // Create certificate ID
+        CertificateID certId = new CertificateID(digCalcProv.get(CertificateID.HASH_SHA1),
+                new X509CertificateHolder(caCert.getEncoded()), serialNumber);
+
+        // Build request
+        OCSPReqBuilder builder = new OCSPReqBuilder();
+        builder.addRequest(certId);
+
+        // Add nonce extension
+        byte[] nonce = null;
+        if (nonceLength > 0) {
+            nonce = new byte[nonceLength];
+            new SecureRandom().nextBytes(nonce);
+            Extension ext = new Extension(OCSPObjectIdentifiers.id_pkix_ocsp_nonce, false,
+                    new DEROctetString(nonce).getEncoded());
+            builder.setRequestExtensions(new Extensions(ext));
+        }
+
+        // Sign the request if signing credentials are provided
+        OCSPReq ocspReq;
+        if (signingKey != null && signingCertChain != null && signingCertChain.length > 0) {
+            // Set requestor name from the signing certificate
+            X509CertificateHolder signingCertHolder = new X509CertificateHolder(signingCertChain[0].getEncoded());
+            builder.setRequestorName(signingCertHolder.getSubject());
+
+            // Convert certificate chain to Bouncy Castle format
+            X509CertificateHolder[] certChainHolders = new X509CertificateHolder[signingCertChain.length];
+            for (int i = 0; i < signingCertChain.length; i++) {
+                certChainHolders[i] = new X509CertificateHolder(signingCertChain[i].getEncoded());
+            }
+
+            // Create content signer
+            org.bouncycastle.operator.ContentSigner signer = new org.bouncycastle.operator.jcajce.JcaContentSignerBuilder("SHA256withRSA")
+                    .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                    .build(signingKey);
+
+            // Build signed request
+            ocspReq = builder.build(signer, certChainHolders);
+        } else {
+            // Build unsigned request
+            ocspReq = builder.build();
+        }
+
+        return new OcspRequestWithNonce(ocspReq, nonce);
+    }
+
+    /**
+     * Send OCSP request and return certificate status
+     */
+    private String sendOcspRequest(OCSPReq ocspReq, String ocspUrl, String reqType, X509Certificate caCert, byte[] requestNonce, boolean verifyNonce, String saveOcspDir, int threadId, int requestNum) throws Exception {
+        byte[] requestBytes = ocspReq.getEncoded();
+
+        CloseableHttpResponse response;
+
+        // Create a simple HTTP client (supports both HTTP and HTTPS)
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            switch (reqType.toUpperCase()) {
+            case "POST":
+                HttpPost postRequest = new HttpPost(ocspUrl);
+                postRequest.setHeader("Content-Type", "application/ocsp-request");
+                postRequest.setEntity(new ByteArrayEntity(requestBytes));
+                response = httpClient.execute(postRequest);
+                break;
+
+            case "GET":
+                // Encode OCSP request as Base64 per RFC 6960 Section A.1.1
+                byte[] base64Bytes = org.bouncycastle.util.encoders.Base64.encode(requestBytes);
+                String base64Req = new String(base64Bytes, java.nio.charset.StandardCharsets.US_ASCII);
+
+                // EJBCA's OCSP servlet expects standard Base64 with URL encoding
+                // It uses URLDecoder.decode() then replaces spaces with '+' before Base64 decoding
+                // So we need to percent-encode the Base64 special characters
+                String urlEncodedBase64 = base64Req
+                    .replace("+", "%2B")  // Percent-encode plus signs
+                    .replace("/", "%2F")  // Percent-encode slashes
+                    .replace("=", "%3D"); // Percent-encode padding
+
+                String getUrl = ocspUrl + "/" + urlEncodedBase64;
+                HttpGet getRequest = new HttpGet(getUrl);
+                response = httpClient.execute(getRequest);
+                break;
+
+            default:
+                throw new IllegalArgumentException("Unknown request type: " + reqType);
+            }
+
+            try {
+                return parseOcspResponse(response, caCert, requestNonce, verifyNonce, saveOcspDir, threadId, requestNum);
+            } finally {
+                response.close();
+            }
+        }
+    }
+
+    /**
+     * Parse OCSP response, verify signature, and extract certificate status
+     */
+    private String parseOcspResponse(CloseableHttpResponse response, X509Certificate caCert, byte[] requestNonce, boolean verifyNonce, String saveOcspDir, int threadId, int requestNum) throws Exception {
+        int statusCode = response.getStatusLine().getStatusCode();
+
+        if (statusCode != 200) {
+            throw new Exception("HTTP error: " + statusCode);
+        }
+
+        byte[] responseBytes = IOUtils.toByteArray(response.getEntity().getContent());
+
+        // Save debug response if enabled
+        saveDebugResponse(responseBytes, saveOcspDir, threadId, requestNum);
+
+        OCSPResp ocspResp = new OCSPResp(responseBytes);
+
+        if (ocspResp.getStatus() != OCSPResp.SUCCESSFUL) {
+            throw new Exception("OCSP response status: " + ocspResp.getStatus());
+        }
+
+        BasicOCSPResp basicResp = (BasicOCSPResp) ocspResp.getResponseObject();
+
+        // Verify OCSP response signature
+        if (!verifyOcspResponseSignature(basicResp, caCert)) {
+            throw new Exception("OCSP response signature verification failed");
+        }
+
+        // Verify nonce if requested
+        if (verifyNonce && requestNonce != null) {
+            if (!verifyResponseNonce(basicResp, requestNonce)) {
+                throw new Exception("OCSP response nonce verification failed");
+            }
+        }
+
+        SingleResp[] responses = basicResp.getResponses();
+
+        if (responses.length == 0) {
+            throw new Exception("No responses in OCSP reply");
+        }
+
+        Object certStatus = responses[0].getCertStatus();
+
+        if (certStatus == null) {
+            return "GOOD";
+        } else if (certStatus instanceof RevokedStatus) {
+            return "REVOKED";
+        } else if (certStatus instanceof UnknownStatus) {
+            return "UNKNOWN";
+        }
+
+        return "UNKNOWN";
+    }
+
+    /**
+     * Verify OCSP response signature using CA certificate
+     */
+    private boolean verifyOcspResponseSignature(BasicOCSPResp basicResp, X509Certificate caCert) {
+        try {
+            // Get certificates from OCSP response (OCSP responder certificate)
+            org.bouncycastle.cert.X509CertificateHolder[] certs = basicResp.getCerts();
+
+            if (certs != null && certs.length > 0) {
+                // OCSP response is signed by a delegated OCSP responder certificate
+                // Verify using the first certificate in the response (OCSP responder cert)
+                org.bouncycastle.cert.X509CertificateHolder responderCert = certs[0];
+
+                // Build content verifier using the OCSP responder's public key
+                org.bouncycastle.operator.ContentVerifierProvider verifierProvider =
+                    new org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder()
+                        .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                        .build(responderCert);
+
+                // Verify the OCSP response signature
+                boolean signatureValid = basicResp.isSignatureValid(verifierProvider);
+
+                if (!signatureValid) {
+                    return false;
+                }
+
+                // TODO: Optionally verify that the OCSP responder certificate is trusted
+                // (issued by the CA certificate or explicitly trusted)
+                // For stress testing purposes, we trust the responder cert if signature is valid
+
+                return true;
+            } else {
+                // OCSP response is signed directly by the CA certificate
+                org.bouncycastle.operator.ContentVerifierProvider verifierProvider =
+                    new org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder()
+                        .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                        .build(caCert.getPublicKey());
+
+                return basicResp.isSignatureValid(verifierProvider);
+            }
+        } catch (Exception e) {
+            log.error("OCSP signature verification error: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Verify that OCSP response nonce matches the request nonce
+     */
+    private boolean verifyResponseNonce(BasicOCSPResp basicResp, byte[] requestNonce) {
+        try {
+            // Get the nonce extension from the response
+            Extension nonceExt = basicResp.getExtension(OCSPObjectIdentifiers.id_pkix_ocsp_nonce);
+
+            if (nonceExt == null) {
+                log.error("OCSP response does not contain a nonce extension");
+                return false;
+            }
+
+            // Extract the nonce value from the extension
+            // The extension value is already a DEROctetString, and getExtnValue() returns its content
+            // which is another DER-encoded octet string containing the actual nonce
+            byte[] extnValueBytes = nonceExt.getExtnValue().getOctets();
+
+            // Parse the inner DEROctetString to get the actual nonce bytes
+            DEROctetString derNonce = (DEROctetString) DEROctetString.fromByteArray(extnValueBytes);
+            byte[] actualNonce = derNonce.getOctets();
+
+            // Compare the nonces
+            if (requestNonce.length != actualNonce.length) {
+                log.error("OCSP nonce length mismatch: request=" + requestNonce.length + ", response=" + actualNonce.length);
+                return false;
+            }
+
+            for (int i = 0; i < requestNonce.length; i++) {
+                if (requestNonce[i] != actualNonce[i]) {
+                    log.error("OCSP nonce mismatch at position " + i);
+                    return false;
+                }
+            }
+
+            return true;
+        } catch (Exception e) {
+            log.error("OCSP nonce verification error: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Save OCSP request to file for debugging
+     */
+    private void saveDebugRequest(OCSPReq ocspReq, String saveDir, int threadId, int requestNum) {
+        if (saveDir == null) {
+            return;
+        }
+
+        try {
+            String filename = String.format("ocsp-req-t%d-r%d.der", threadId, requestNum);
+            File debugFile = new File(saveDir, filename);
+            Files.write(debugFile.toPath(), ocspReq.getEncoded());
+        } catch (Exception e) {
+            // Silently ignore debug save failures
+            log.debug("Failed to save OCSP request: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Save OCSP response to file for debugging
+     */
+    private void saveDebugResponse(byte[] responseBytes, String saveDir, int threadId, int requestNum) {
+        if (saveDir == null) {
+            return;
+        }
+
+        try {
+            String filename = String.format("ocsp-resp-t%d-r%d.der", threadId, requestNum);
+            File debugFile = new File(saveDir, filename);
+            Files.write(debugFile.toPath(), responseBytes);
+        } catch (Exception e) {
+            // Silently ignore debug save failures
+            log.debug("Failed to save OCSP response: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Report aggregated statistics from all threads
+     */
+    private void reportStatistics(List<OcspTestResult> results, long duration) {
+        // Aggregate counts
+        long totalRequests = 0;
+        long totalFailures = 0;
+        Map<String, Integer> totalStatusCounts = new HashMap<>();
+        List<Long> allResponseTimes = new ArrayList<>();
+
+        for (OcspTestResult result : results) {
+            totalRequests += result.responseTimes.size() + result.failures.size();
+            totalFailures += result.failures.size();
+
+            for (Map.Entry<String, Integer> entry : result.statusCounts.entrySet()) {
+                totalStatusCounts.merge(entry.getKey(), entry.getValue(), Integer::sum);
+            }
+
+            allResponseTimes.addAll(result.responseTimes);
+        }
+
+        long successfulRequests = totalRequests - totalFailures;
+        double executionTime = duration / 1000.0;
+
+        log.info("");
+        log.info("===== OCSP Stress Test Results =====");
+        log.info("Total execution time: " + String.format("%.2f", executionTime) + " seconds");
+        log.info("Total requests: " + totalRequests);
+        log.info("Successful requests: " + successfulRequests);
+        log.info("Failed requests: " + totalFailures);
+        if (executionTime > 0) {
+            log.info("Throughput: " + String.format("%.2f", totalRequests / executionTime) + " requests/second");
+        }
+
+        // Response time statistics
+        if (!allResponseTimes.isEmpty()) {
+            Collections.sort(allResponseTimes);
+            long minTime = allResponseTimes.get(0);
+            long maxTime = allResponseTimes.get(allResponseTimes.size() - 1);
+            long avgTime = allResponseTimes.stream().mapToLong(Long::longValue).sum() / allResponseTimes.size();
+            long p50Time = allResponseTimes.get(allResponseTimes.size() / 2);
+            long p95Time = allResponseTimes.get((int) (allResponseTimes.size() * 0.95));
+            long p99Time = allResponseTimes.get((int) (allResponseTimes.size() * 0.99));
+
+            log.info("");
+            log.info("Response Times (ms):");
+            log.info("  Min: " + minTime);
+            log.info("  Max: " + maxTime);
+            log.info("  Avg: " + avgTime);
+            log.info("  P50: " + p50Time);
+            log.info("  P95: " + p95Time);
+            log.info("  P99: " + p99Time);
+        }
+
+        // Certificate status breakdown
+        if (!totalStatusCounts.isEmpty()) {
+            log.info("");
+            log.info("Certificate Status Distribution:");
+            for (Map.Entry<String, Integer> entry : totalStatusCounts.entrySet()) {
+                log.info("  " + entry.getKey() + ": " + entry.getValue());
+            }
+        }
+    }
+
+    /**
+     * Report aggregated statistics from all threads to console (for shutdown hook)
+     * Uses System.out instead of logger to ensure output during JVM shutdown
+     */
+    private void reportStatisticsToConsole(List<OcspTestResult> results, long duration) {
+        // Aggregate counts
+        long totalRequests = 0;
+        long totalFailures = 0;
+        Map<String, Integer> totalStatusCounts = new HashMap<>();
+        List<Long> allResponseTimes = new ArrayList<>();
+
+        for (OcspTestResult result : results) {
+            totalRequests += result.responseTimes.size() + result.failures.size();
+            totalFailures += result.failures.size();
+
+            for (Map.Entry<String, Integer> entry : result.statusCounts.entrySet()) {
+                totalStatusCounts.merge(entry.getKey(), entry.getValue(), Integer::sum);
+            }
+
+            allResponseTimes.addAll(result.responseTimes);
+        }
+
+        long successfulRequests = totalRequests - totalFailures;
+        double executionTime = duration / 1000.0;
+
+        System.out.println();
+        System.out.println("===== OCSP Stress Test Results =====");
+        System.out.println("Total execution time: " + String.format("%.2f", executionTime) + " seconds");
+        System.out.println("Total requests: " + totalRequests);
+        System.out.println("Successful requests: " + successfulRequests);
+        System.out.println("Failed requests: " + totalFailures);
+        if (executionTime > 0) {
+            System.out.println("Throughput: " + String.format("%.2f", totalRequests / executionTime) + " requests/second");
+        }
+
+        // Response time statistics
+        if (!allResponseTimes.isEmpty()) {
+            Collections.sort(allResponseTimes);
+            long minTime = allResponseTimes.get(0);
+            long maxTime = allResponseTimes.get(allResponseTimes.size() - 1);
+            long avgTime = allResponseTimes.stream().mapToLong(Long::longValue).sum() / allResponseTimes.size();
+            long p50Time = allResponseTimes.get(allResponseTimes.size() / 2);
+            long p95Time = allResponseTimes.get((int) (allResponseTimes.size() * 0.95));
+            long p99Time = allResponseTimes.get((int) (allResponseTimes.size() * 0.99));
+
+            System.out.println();
+            System.out.println("Response Times (ms):");
+            System.out.println("  Min: " + minTime);
+            System.out.println("  Max: " + maxTime);
+            System.out.println("  Avg: " + avgTime);
+            System.out.println("  P50: " + p50Time);
+            System.out.println("  P95: " + p95Time);
+            System.out.println("  P99: " + p99Time);
+        }
+
+        // Certificate status breakdown
+        if (!totalStatusCounts.isEmpty()) {
+            System.out.println();
+            System.out.println("Certificate Status Distribution:");
+            for (Map.Entry<String, Integer> entry : totalStatusCounts.entrySet()) {
+                System.out.println("  " + entry.getKey() + ": " + entry.getValue());
+            }
+        }
+        System.out.println();
+    }
+
+    /**
+     * Write test results to CSV file
+     */
+    private void writeResultsToCsv(String filename, List<OcspTestResult> results, long duration) throws IOException {
+        // Aggregate counts
+        long totalRequests = 0;
+        long totalFailures = 0;
+        Map<String, Integer> totalStatusCounts = new HashMap<>();
+        List<Long> allResponseTimes = new ArrayList<>();
+
+        for (OcspTestResult result : results) {
+            totalRequests += result.responseTimes.size() + result.failures.size();
+            totalFailures += result.failures.size();
+
+            for (Map.Entry<String, Integer> entry : result.statusCounts.entrySet()) {
+                totalStatusCounts.merge(entry.getKey(), entry.getValue(), Integer::sum);
+            }
+
+            allResponseTimes.addAll(result.responseTimes);
+        }
+
+        long successfulRequests = totalRequests - totalFailures;
+        double executionTime = duration / 1000.0;
+        double throughput = executionTime > 0 ? totalRequests / executionTime : 0;
+
+        // Calculate response time statistics
+        long minTime = 0, maxTime = 0, avgTime = 0, p50Time = 0, p95Time = 0, p99Time = 0;
+        if (!allResponseTimes.isEmpty()) {
+            Collections.sort(allResponseTimes);
+            minTime = allResponseTimes.get(0);
+            maxTime = allResponseTimes.get(allResponseTimes.size() - 1);
+            avgTime = allResponseTimes.stream().mapToLong(Long::longValue).sum() / allResponseTimes.size();
+            p50Time = allResponseTimes.get(allResponseTimes.size() / 2);
+            p95Time = allResponseTimes.get((int) (allResponseTimes.size() * 0.95));
+            p99Time = allResponseTimes.get((int) (allResponseTimes.size() * 0.99));
+        }
+
+        // Get status counts
+        int goodCount = totalStatusCounts.getOrDefault("GOOD", 0);
+        int revokedCount = totalStatusCounts.getOrDefault("REVOKED", 0);
+        int unknownCount = totalStatusCounts.getOrDefault("UNKNOWN", 0);
+
+        try (PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(filename)))) {
+            // Write header
+            writer.println("Test Duration (s),Total Requests,Successful,Failed,Throughput (req/s),Min Response (ms),Max Response (ms),Avg Response (ms),P50 (ms),P95 (ms),P99 (ms),GOOD,REVOKED,UNKNOWN,Timestamp");
+
+            // Write data row
+            String timestamp = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
+            writer.println(String.format("%.2f,%d,%d,%d,%.2f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%s",
+                    executionTime, totalRequests, successfulRequests, totalFailures, throughput,
+                    minTime, maxTime, avgTime, p50Time, p95Time, p99Time,
+                    goodCount, revokedCount, unknownCount, timestamp));
+        }
+    }
+
+    /**
+     * Write test results to Markdown file
+     */
+    private void writeResultsToMarkdown(String filename, List<OcspTestResult> results, long duration) throws IOException {
+        // Aggregate counts
+        long totalRequests = 0;
+        long totalFailures = 0;
+        Map<String, Integer> totalStatusCounts = new HashMap<>();
+        List<Long> allResponseTimes = new ArrayList<>();
+
+        for (OcspTestResult result : results) {
+            totalRequests += result.responseTimes.size() + result.failures.size();
+            totalFailures += result.failures.size();
+
+            for (Map.Entry<String, Integer> entry : result.statusCounts.entrySet()) {
+                totalStatusCounts.merge(entry.getKey(), entry.getValue(), Integer::sum);
+            }
+
+            allResponseTimes.addAll(result.responseTimes);
+        }
+
+        long successfulRequests = totalRequests - totalFailures;
+        double executionTime = duration / 1000.0;
+        double throughput = executionTime > 0 ? totalRequests / executionTime : 0;
+
+        // Calculate response time statistics
+        long minTime = 0, maxTime = 0, avgTime = 0, p50Time = 0, p95Time = 0, p99Time = 0;
+        if (!allResponseTimes.isEmpty()) {
+            Collections.sort(allResponseTimes);
+            minTime = allResponseTimes.get(0);
+            maxTime = allResponseTimes.get(allResponseTimes.size() - 1);
+            avgTime = allResponseTimes.stream().mapToLong(Long::longValue).sum() / allResponseTimes.size();
+            p50Time = allResponseTimes.get(allResponseTimes.size() / 2);
+            p95Time = allResponseTimes.get((int) (allResponseTimes.size() * 0.95));
+            p99Time = allResponseTimes.get((int) (allResponseTimes.size() * 0.99));
+        }
+
+        // Get status counts
+        int goodCount = totalStatusCounts.getOrDefault("GOOD", 0);
+        int revokedCount = totalStatusCounts.getOrDefault("REVOKED", 0);
+        int unknownCount = totalStatusCounts.getOrDefault("UNKNOWN", 0);
+
+        String timestamp = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
+
+        try (PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(filename)))) {
+            writer.println("# OCSP Stress Test Results");
+            writer.println();
+            writer.println("**Generated:** " + timestamp);
+            writer.println();
+
+            // Test Configuration section
+            writer.println("## Test Configuration");
+            writer.println();
+            writer.println("| Metric | Value |");
+            writer.println("|--------|-------|");
+            writer.println(String.format("| Test Duration | %.2f seconds |", executionTime));
+            writer.println();
+
+            // Performance Metrics table
+            writer.println("## Performance Metrics");
+            writer.println();
+            writer.println("| Metric | Value |");
+            writer.println("|--------|-------|");
+            writer.println(String.format("| Total Requests | %,d |", totalRequests));
+            writer.println(String.format("| Successful Requests | %,d |", successfulRequests));
+            writer.println(String.format("| Failed Requests | %,d |", totalFailures));
+            writer.println(String.format("| Throughput | %.2f req/s |", throughput));
+            writer.println();
+
+            // Response Times table
+            writer.println("## Response Times");
+            writer.println();
+            writer.println("| Percentile | Response Time (ms) |");
+            writer.println("|------------|-------------------|");
+            writer.println(String.format("| Minimum | %d |", minTime));
+            writer.println(String.format("| Average | %d |", avgTime));
+            writer.println(String.format("| P50 (Median) | %d |", p50Time));
+            writer.println(String.format("| P95 | %d |", p95Time));
+            writer.println(String.format("| P99 | %d |", p99Time));
+            writer.println(String.format("| Maximum | %d |", maxTime));
+            writer.println();
+
+            // Certificate Status table
+            writer.println("## Certificate Status Distribution");
+            writer.println();
+            writer.println("| Status | Count |");
+            writer.println("|--------|-------|");
+            writer.println(String.format("| GOOD | %,d |", goodCount));
+            writer.println(String.format("| REVOKED | %,d |", revokedCount));
+            writer.println(String.format("| UNKNOWN | %,d |", unknownCount));
+            writer.println();
+        }
+    }
+
+    @Override
+    public String getMainCommand() {
+        return "ocspstress";
+    }
+
+    @Override
+    public String getCommandDescription() {
+        return "Performs multi-threaded OCSP stress testing against an OCSP responder";
+    }
+
+    @Override
+    public String getFullHelpText() {
+        return getCommandDescription()
+                + "\n\nSupports both POST and GET request types. Serial number file can be either:\n"
+                + "  - Simple list: one serial number per line (decimal or hex with 0x prefix)\n"
+                + "  - Pipe-delimited: serialNumber|issuerDn (from --savecerts flag)\n\n";
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return log;
+    }
+}

--- a/src/main/java/com/keyfactor/ejbca/client/stress/X509StressTestCommand.java
+++ b/src/main/java/com/keyfactor/ejbca/client/stress/X509StressTestCommand.java
@@ -12,6 +12,10 @@
  *************************************************************************/
 package com.keyfactor.ejbca.client.stress;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -23,7 +27,11 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -36,6 +44,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
 import org.apache.log4j.Logger;
 import org.bouncycastle.asn1.ASN1EncodableVector;
@@ -60,11 +69,15 @@ import org.ejbca.ui.cli.infrastructure.parameter.enums.StandaloneMode;
 import org.json.simple.JSONObject;
 
 import com.keyfactor.ejbca.client.ErceCommandBase;
+import com.keyfactor.util.Base64;
 import com.keyfactor.util.CertTools;
 import com.keyfactor.util.certificate.DnComponents;
 import com.keyfactor.util.crypto.algorithm.AlgorithmConstants;
 import com.keyfactor.util.crypto.algorithm.AlgorithmTools;
 import com.keyfactor.util.keys.KeyTools;
+
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 /**
  * This class provides the ability to use ERCE to perform a stress test against
@@ -77,6 +90,9 @@ public class X509StressTestCommand extends ErceCommandBase {
 
 	private static final String STRESS_TEST_PREFIX_DEFAULT = "ErceStressTest_";
 	private static final String COMMAND_URL = "/ejbca/ejbca-rest-api/v1/certificate/pkcs10enroll";
+	private static final String REVOKE_URL_PREFIX = "/ejbca/ejbca-rest-api/v1/certificate/";
+	private static final String REVOKE_URL_SUFFIX = "/revoke";
+	private static final String REVOCATION_REASON = "UNSPECIFIED";
 
 	private static final String CA_ARG = "--ca";
 	private static final String CERTIFICATE_PROFILE_ARG = "--certificateprofile";
@@ -90,6 +106,11 @@ public class X509StressTestCommand extends ErceCommandBase {
 	private static final String KEYSPEC_ARG = "--keyspec";
 	private static final String SUBJECTDN_ARG = "--subjectdn";
 	private static final String SAN_ARG = "--san";
+	private static final String HISTORY_ARG = "--history";
+	private static final String REVOKE_ARG = "--revoke";
+	private static final String BACKDATEREVOKE_ARG = "--backdaterevoke";
+	private static final String SAVECERTS_ARG = "--savecerts";
+	private static final String REVOKEFILE_ARG = "--revokefile";
 
 	private static final Set<String> RSA_KEY_SIZES = new LinkedHashSet<>(
 			Arrays.asList("1024", "1536", "2048", "3072", "4096", "6144", "8192"));
@@ -98,17 +119,56 @@ public class X509StressTestCommand extends ErceCommandBase {
 	private String[][] payloads;
 	private String[][] subjectDns;
 
+	// Inner class to hold stress test results
+	private static class StressTestResult {
+		List<String> issuanceFailures;
+		List<String> revocationFailures;
+		List<CertificateInfo> issuedCertificates;
+
+		StressTestResult(List<String> issuanceFailures, List<String> revocationFailures, List<CertificateInfo> issuedCertificates) {
+			this.issuanceFailures = issuanceFailures;
+			this.revocationFailures = revocationFailures;
+			this.issuedCertificates = issuedCertificates;
+		}
+	}
+
+	// Inner class to hold certificate information for saving/loading
+	private static class CertificateInfo {
+		String serialNumber;
+		String issuerDn;
+
+		CertificateInfo(String serialNumber, String issuerDn) {
+			this.serialNumber = serialNumber;
+			this.issuerDn = issuerDn;
+		}
+
+		// Parse from file format: serialNumber|issuerDn
+		static CertificateInfo fromString(String line) {
+			String[] parts = line.split("\\|", 2);
+			if (parts.length == 2) {
+				return new CertificateInfo(parts[0], parts[1]);
+			}
+			return null;
+		}
+
+		// Convert to file format: serialNumber|issuerDn
+		@Override
+		public String toString() {
+			return serialNumber + "|" + issuerDn;
+		}
+	}
+
 	{
-		registerParameter(new Parameter(CA_ARG, "CA Name", MandatoryMode.MANDATORY, StandaloneMode.FORBID,
-				ParameterMode.ARGUMENT, "Name of the Certificate Authority to test against."));
-		registerParameter(new Parameter(END_ENTITY_PROFILE_ARG, "End Entity Profile Name", MandatoryMode.MANDATORY,
-				StandaloneMode.FORBID, ParameterMode.ARGUMENT, "End Entity Profile Name"));
-		registerParameter(new Parameter(CERTIFICATE_PROFILE_ARG, "Certificate Profile Name", MandatoryMode.MANDATORY,
-				StandaloneMode.FORBID, ParameterMode.ARGUMENT, "Certificate Profile Name"));
+		registerParameter(new Parameter(CA_ARG, "CA Name", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+				ParameterMode.ARGUMENT, "Name of the Certificate Authority to test against. Required for certificate issuance, not needed for --revokefile."));
+		registerParameter(new Parameter(END_ENTITY_PROFILE_ARG, "End Entity Profile Name", MandatoryMode.OPTIONAL,
+				StandaloneMode.FORBID, ParameterMode.ARGUMENT, "End Entity Profile Name. Required for certificate issuance, not needed for --revokefile."));
+		registerParameter(new Parameter(CERTIFICATE_PROFILE_ARG, "Certificate Profile Name", MandatoryMode.OPTIONAL,
+				StandaloneMode.FORBID, ParameterMode.ARGUMENT, "Certificate Profile Name. Required for certificate issuance, not needed for --revokefile."));
 		registerParameter(new Parameter(THREADS_ARG, "Numeric Value", MandatoryMode.MANDATORY, StandaloneMode.FORBID,
 				ParameterMode.ARGUMENT, "Number of threads."));
-		registerParameter(new Parameter(CERTS_PER_THREAD_ARG, "Numeric Value", MandatoryMode.MANDATORY,
-				StandaloneMode.FORBID, ParameterMode.ARGUMENT, "Number CSRs to generate per thread."));
+		registerParameter(new Parameter(CERTS_PER_THREAD_ARG, "Numeric Value", MandatoryMode.OPTIONAL,
+				StandaloneMode.FORBID, ParameterMode.ARGUMENT, "Number CSRs to generate per thread. Required for certificate issuance, not needed for --revokefile."));
 		registerParameter(new Parameter(REUSE_KEY_ARG, "", MandatoryMode.OPTIONAL,
 				StandaloneMode.FORBID, ParameterMode.FLAG, "Set this flag to use the same key for all CSRs. Be aware that unique public keys must be disabled on the CA."));
 		registerParameter(new Parameter(PREFIX_ARG, "prefix", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
@@ -138,11 +198,68 @@ public class X509StressTestCommand extends ErceCommandBase {
 				ParameterMode.ARGUMENT, "Optional Subject DN for certificates. If a CN attribute is present, the prefix and postfix will be applied to it. Default is 'CN=<prefix>_<threadId>_<certId>_<postfix>'."));
 		registerParameter(new Parameter(SAN_ARG, "Subject Alternative Name", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
 				ParameterMode.ARGUMENT, "Optional Subject Alternative Name (SAN) for certificates. Format: 'dnsName=example.com' or 'dnsName=example.com,ipAddress=192.168.1.1'. If a dnsName is provided, the prefix and postfix will be applied to it."));
+		registerParameter(new Parameter(HISTORY_ARG, "Numeric Value", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+				ParameterMode.ARGUMENT, "Number of additional certificates to issue per end entity with unique keys. This allows testing certificate history in EJBCA. Default is 0 (no additional certificates)."));
+		registerParameter(new Parameter(REVOKE_ARG, "", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+				ParameterMode.FLAG, "Set this flag to revoke certificates after successful issuance. Useful for testing revocation performance and certificate lifecycle."));
+		registerParameter(new Parameter(BACKDATEREVOKE_ARG, "", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+				ParameterMode.FLAG, "Set this flag along with --revoke to use the certificate's notBefore date for revocation instead of the current time. Allows backdated revocation for certificate profiles that permit it."));
+		registerParameter(new Parameter(SAVECERTS_ARG, "filename", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+				ParameterMode.ARGUMENT, "Save issued certificate information (serial number and issuer DN) to specified file for later bulk revocation."));
+		registerParameter(new Parameter(REVOKEFILE_ARG, "filename", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+				ParameterMode.ARGUMENT, "Perform bulk revocation of certificates listed in the specified file (created with --savecerts). When this flag is used, no new certificates are issued."));
 
 	}
 
 	@Override
 	protected CommandResult execute(ParameterContainer parameters) {
+		// Check if running in bulk revocation mode
+		final String revokeFile = parameters.get(REVOKEFILE_ARG);
+		final boolean isBulkRevocationMode = !StringUtils.isBlank(revokeFile);
+
+		// Validate required parameters based on mode
+		if (!isBulkRevocationMode) {
+			// Enrollment mode: require CA, profiles, and certs parameters
+			if (StringUtils.isBlank(parameters.get(CA_ARG))) {
+				log.error(CA_ARG + " is required for certificate issuance. Use --help for more information.");
+				return CommandResult.CLI_FAILURE;
+			}
+			if (StringUtils.isBlank(parameters.get(END_ENTITY_PROFILE_ARG))) {
+				log.error(END_ENTITY_PROFILE_ARG + " is required for certificate issuance. Use --help for more information.");
+				return CommandResult.CLI_FAILURE;
+			}
+			if (StringUtils.isBlank(parameters.get(CERTIFICATE_PROFILE_ARG))) {
+				log.error(CERTIFICATE_PROFILE_ARG + " is required for certificate issuance. Use --help for more information.");
+				return CommandResult.CLI_FAILURE;
+			}
+			if (StringUtils.isBlank(parameters.get(CERTS_PER_THREAD_ARG))) {
+				log.error(CERTS_PER_THREAD_ARG + " is required for certificate issuance. Use --help for more information.");
+				return CommandResult.CLI_FAILURE;
+			}
+		}
+
+		// Parse thread count (required for both modes)
+		final int numberOfThreads;
+		try {
+			numberOfThreads = Integer.valueOf(parameters.get(THREADS_ARG));
+		} catch (NumberFormatException e) {
+			log.error(THREADS_ARG + " was not a numeric value");
+			return CommandResult.CLI_FAILURE;
+		}
+		if (numberOfThreads < 1) {
+			log.error(THREADS_ARG + " must be a positive value");
+			return CommandResult.CLI_FAILURE;
+		}
+
+		// Parse revocation flags
+		final boolean backdateRevocation = parameters.containsKey(BACKDATEREVOKE_ARG);
+
+		// If --revokefile is specified, perform bulk revocation instead of enrollment
+		if (isBulkRevocationMode) {
+			return performBulkRevocation(revokeFile, backdateRevocation, numberOfThreads);
+		}
+
+		// Below this point: enrollment mode only
 		final String endEntityProfileName = parameters.get(END_ENTITY_PROFILE_ARG);
 		final String certificateProfileName = parameters.get(CERTIFICATE_PROFILE_ARG);
 		final String caName = parameters.get(CA_ARG);
@@ -172,6 +289,25 @@ public class X509StressTestCommand extends ErceCommandBase {
 		} else {
 			subjectAltName = null;
 		}
+
+		final int historyCount;
+		if(parameters.containsKey(HISTORY_ARG)) {
+			try {
+				historyCount = Integer.valueOf(parameters.get(HISTORY_ARG));
+			} catch (NumberFormatException e) {
+				log.error(HISTORY_ARG + " was not a numeric value");
+				return CommandResult.CLI_FAILURE;
+			}
+			if (historyCount < 0) {
+				log.error(HISTORY_ARG + " must be a non-negative value");
+				return CommandResult.CLI_FAILURE;
+			}
+		} else {
+			historyCount = 0;
+		}
+
+		final boolean revokeAfterIssuance = parameters.containsKey(REVOKE_ARG);
+		final String saveCertsFile = parameters.get(SAVECERTS_ARG);
 
 		// Parse and validate key algorithm
 		String keyAlg = parameters.get(KEYALG_ARG);
@@ -229,18 +365,6 @@ public class X509StressTestCommand extends ErceCommandBase {
 		final String restUrl = new StringBuilder().append("https://").append(getHostname()).append(COMMAND_URL)
 				.toString();
 
-		final int numberOfThreads;
-		try {
-			numberOfThreads = Integer.valueOf(parameters.get(THREADS_ARG));
-		} catch (NumberFormatException e) {
-			log.error(THREADS_ARG + " was not a numeric value");
-			return CommandResult.CLI_FAILURE;
-		}
-		if (numberOfThreads < 1) {
-			log.error(THREADS_ARG + " must be a positive value");
-			return CommandResult.CLI_FAILURE;
-		}
-
 		final int requestPerThread;
 		try {
 			requestPerThread = Integer.valueOf(parameters.get(CERTS_PER_THREAD_ARG));
@@ -252,10 +376,10 @@ public class X509StressTestCommand extends ErceCommandBase {
 			log.error(CERTS_PER_THREAD_ARG + " must be a positive value");
 			return CommandResult.CLI_FAILURE;
 		}
-		
+
 		final boolean singleKey = parameters.containsKey(REUSE_KEY_ARG);
 
-		generatePayloads(numberOfThreads, requestPerThread, caName, certificateProfileName, endEntityProfileName, singleKey, prefix, postfix, keyAlg, keySpec, subjectDn, subjectAltName);
+		generatePayloads(numberOfThreads, requestPerThread, caName, certificateProfileName, endEntityProfileName, singleKey, prefix, postfix, keyAlg, keySpec, subjectDn, subjectAltName, historyCount);
 		log.info("All CSR payloads transferred to caches..\n\nPreparing orbital bombardment in....");
 		try {
 			for (int i = 3; i > 0; --i) {
@@ -267,15 +391,21 @@ public class X509StressTestCommand extends ErceCommandBase {
 		}
 		
 		log.info("\nWeapons free. Fire for effect.");
-		
+
+		// Calculate total payloads per thread considering history certificates
+		final int certsPerEntity = 1 + historyCount;
+		final int totalPayloadsPerThread = requestPerThread * certsPerEntity;
+
 		long startTime = System.currentTimeMillis();
-		List<CompletableFuture<List<String>>> futures = new ArrayList<>();
+		List<CompletableFuture<StressTestResult>> futures = new ArrayList<>();
 		for (int threadNumber = 0; threadNumber < numberOfThreads; ++threadNumber) {
 			final int row = threadNumber;
 			futures.add(CompletableFuture.supplyAsync(() -> {
 
-				List<String> failures = new ArrayList<>();
-				for (int i = 0; i < requestPerThread; ++i) {
+				List<String> issuanceFailures = new ArrayList<>();
+				List<String> revocationFailures = new ArrayList<>();
+				List<CertificateInfo> issuedCertificates = new ArrayList<>();
+				for (int i = 0; i < totalPayloadsPerThread; ++i) {
 					String payload = payloads[row][i];
 					String certSubjectDn = subjectDns[row][i];
 					String cnInfo = extractCNForErrorMessage(certSubjectDn);
@@ -290,17 +420,38 @@ public class X509StressTestCommand extends ErceCommandBase {
 							case 404:
 								String msg404 =  "Thread ID: " + row + ", Iteration: " + i + cnInfo + " - Return code was: 404: " + responseString;
 								getLogger().error(msg404);
-								failures.add(msg404);
+								issuanceFailures.add(msg404);
 								break;
 							case 200:
 							case 201:
-								// Do nothing.
+								// Certificate issued successfully
+								try {
+									final JSONParser jsonParser = new JSONParser();
+									final JSONObject actualJsonObject = (JSONObject) jsonParser.parse(responseString);
+									final String base64cert = (String) actualJsonObject.get("certificate");
+									byte[] certBytes = Base64.decode(base64cert.getBytes());
+									X509Certificate certificate = CertTools.getCertfromByteArray(certBytes, X509Certificate.class);
+
+									// Track issued certificate
+									String serialNumber = CertTools.getSerialNumberAsString(certificate);
+									String issuerDn = CertTools.getIssuerDN(certificate);
+									issuedCertificates.add(new CertificateInfo(serialNumber, issuerDn));
+
+									// Revoke if requested
+									if (revokeAfterIssuance) {
+										revokeCertificate(certificate, issuerDn, serialNumber, backdateRevocation, row, i, cnInfo, revocationFailures);
+									}
+								} catch (ParseException | CertificateParsingException e) {
+									String msgParseError = "Thread ID: " + row + ", Iteration: " + i + cnInfo + " - Failed to parse certificate: " + e.getMessage();
+									getLogger().error(msgParseError);
+									issuanceFailures.add(msgParseError);
+								}
 								break;
 							default:
 								String msgOthers = "Thread ID: " + row + ", Iteration: " + i + cnInfo + " - Return code was: " + response.getStatusLine().getStatusCode() + ": "
 										+ responseString;
 								getLogger().error(msgOthers);
-								failures.add(msgOthers);
+								issuanceFailures.add(msgOthers);
 								break;
 							}
 						} catch (KeyManagementException | UnrecoverableKeyException | NoSuchAlgorithmException
@@ -311,45 +462,69 @@ public class X509StressTestCommand extends ErceCommandBase {
 						getLogger().error("Could not perform request: " + e.getMessage());
 					}
 				}
-				return failures;
+				return new StressTestResult(issuanceFailures, revocationFailures, issuedCertificates);
 			}));
 
 		}
 		CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(CompletableFuture<?>[]::new));
-		List<String> results = new ArrayList<>();
+		List<String> issuanceResults = new ArrayList<>();
+		List<String> revocationResults = new ArrayList<>();
+		List<CertificateInfo> allIssuedCertificates = new ArrayList<>();
 		allFutures.thenRun(() -> {
-			for (CompletableFuture<List<String>> completedFuture : futures) {
+			for (CompletableFuture<StressTestResult> completedFuture : futures) {
 				try {
-					results.addAll(completedFuture.get());
+					StressTestResult result = completedFuture.get();
+					issuanceResults.addAll(result.issuanceFailures);
+					revocationResults.addAll(result.revocationFailures);
+					allIssuedCertificates.addAll(result.issuedCertificates);
 				} catch (ExecutionException | InterruptedException e) {
 					log.error("Future could not execute.", e);
 				}
 			}
 		});
-		
+
 		allFutures.join();
 		long endTime = System.currentTimeMillis();
 		log.info("Fire mission complete. Weapons hold.\n");
 
-		if(!results.isEmpty()) {
+		if(!issuanceResults.isEmpty()) {
 			log.info("The following threads did not return a certificate:");
-			for(String error : results) {
+			for(String error : issuanceResults) {
 				log.info(error);
 			}
-			
 		}
-		
-		long totalCerts = numberOfThreads*requestPerThread;
-		long success = totalCerts-results.size();
+
+		if(!revocationResults.isEmpty()) {
+			log.info("\nThe following certificates failed to revoke:");
+			for(String error : revocationResults) {
+				log.info(error);
+			}
+		}
+
+		final int certsPerEntityFinal = 1 + historyCount;
+		long totalCerts = numberOfThreads * requestPerThread * certsPerEntityFinal;
+		long totalEntities = numberOfThreads * requestPerThread;
+		long successfulIssuances = totalCerts - issuanceResults.size();
 		double executionTime =  (endTime - startTime)/1000;
 		log.info("Total execution time: " + executionTime + " seconds.");
-		if(success > 0) {
-			double averageTime = executionTime / success;
+		if(successfulIssuances > 0) {
+			double averageTime = executionTime / successfulIssuances;
 			log.info("Average issuance time: " + averageTime + " seconds.");
 			log.info("Throughput: " + 1 / averageTime + " certificates issued per second.");
 		}
-		log.info((success) + " certificates were successfully issued, with " + results.size() + " failures.");
-		
+		log.info((successfulIssuances) + " certificates were successfully issued, with " + issuanceResults.size() + " issuance failures.");
+		if(revokeAfterIssuance) {
+			long successfulRevocations = successfulIssuances - revocationResults.size();
+			log.info((successfulRevocations) + " certificates were successfully revoked, with " + revocationResults.size() + " revocation failures.");
+		}
+		if(historyCount > 0) {
+			log.info("Total end entities: " + totalEntities + " (" + certsPerEntityFinal + " certificate(s) per entity).");
+		}
+
+		// Save certificates if requested
+		if (!StringUtils.isBlank(saveCertsFile) && !allIssuedCertificates.isEmpty()) {
+			saveCertificatesToFile(allIssuedCertificates, saveCertsFile);
+		}
 
 		return CommandResult.SUCCESS;
 	}
@@ -391,18 +566,27 @@ public class X509StressTestCommand extends ErceCommandBase {
 
 	@SuppressWarnings("unchecked")
 	private void generatePayloads(final int numberOfThreads, final int requestPerThread, final String caName,
-			final String certificateProfileName, final String endEntityProfileName, final boolean singleKey, final String prefix, final String postfix, final String keyAlg, final String keySpec, final String customSubjectDn, final String customSubjectAltName) {
-		log.info("Will submit a total of " + requestPerThread * numberOfThreads + " CSRs, using " + numberOfThreads
+			final String certificateProfileName, final String endEntityProfileName, final boolean singleKey, final String prefix, final String postfix, final String keyAlg, final String keySpec, final String customSubjectDn, final String customSubjectAltName, final int historyCount) {
+		// Calculate total certificates: base certificates + additional history certificates
+		final int certsPerEntity = 1 + historyCount;
+		final int totalCertsPerThread = requestPerThread * certsPerEntity;
+
+		log.info("Will submit a total of " + (requestPerThread * numberOfThreads * certsPerEntity) + " CSRs, using " + numberOfThreads
 				+ " threads.");
+		if (historyCount > 0) {
+			log.info("Certificate history testing enabled: " + certsPerEntity + " certificate(s) per end entity (" + historyCount + " additional).");
+		}
 		log.info("Pre generating CSR payloads...");
 		final String password = "foo123";
-		this.payloads = new String[numberOfThreads][requestPerThread];
-		this.subjectDns = new String[numberOfThreads][requestPerThread];
+		this.payloads = new String[numberOfThreads][totalCertsPerThread];
+		this.subjectDns = new String[numberOfThreads][totalCertsPerThread];
 		final int increment = numberOfThreads / 10;
 		int counter = 0;
 		KeyPair keyPair = null;	
 		try {
+			int payloadIndex = 0;
 			for (int i = 0; i < numberOfThreads; ++i) {
+				payloadIndex = 0;
 				for (int j = 0; j < requestPerThread; ++j) {
 					final String endEntityName = prefix + "_" + i + "_" + j + (StringUtils.isEmpty(postfix) ? "" : "_" + postfix);
 					final String subjectDn;
@@ -432,35 +616,39 @@ public class X509StressTestCommand extends ErceCommandBase {
 						}
 					}
 
-					if (keyPair == null || !singleKey) {
-						try {
-							keyPair = KeyTools.genKeys(keySpec, keyAlg);
-						} catch (InvalidAlgorithmParameterException e) {
-							throw new IllegalStateException("Could not generate key pairs.", e);
+					// Generate certificates for this end entity (1 base + historyCount additional)
+					for (int h = 0; h < certsPerEntity; ++h) {
+						if (keyPair == null || !singleKey) {
+							try {
+								keyPair = KeyTools.genKeys(keySpec, keyAlg);
+							} catch (InvalidAlgorithmParameterException e) {
+								throw new IllegalStateException("Could not generate key pairs.", e);
+							}
 						}
+						// Handle empty subject DN when only SAN is provided
+						final X500Name userDN = StringUtils.isBlank(subjectDn) ? new X500Name("") : DnComponents.stringToBcX500Name(subjectDn);
+						final PKCS10CertificationRequest pkcs10 = generateCertificateRequest(
+								userDN, keyPair, keyAlg, subjectAltName);
+						final StringWriter pemout = new StringWriter();
+						JcaPEMWriter pm = new JcaPEMWriter(pemout);
+						pm.writeObject(pkcs10);
+						pm.close();
+						final String p10pem = pemout.toString();
+						JSONObject param = new JSONObject();
+						param.put("certificate_request", p10pem);
+						param.put("certificate_profile_name", certificateProfileName);
+						param.put("end_entity_profile_name", endEntityProfileName);
+						param.put("certificate_authority_name", caName);
+						param.put("username", endEntityName);
+						param.put("password", password);
+						param.put("include_chain", "false");
+						final StringWriter out = new StringWriter();
+						param.writeJSONString(out);
+						final String payload = out.toString();
+						this.payloads[i][payloadIndex] = payload;
+						this.subjectDns[i][payloadIndex] = subjectDn;
+						payloadIndex++;
 					}
-					// Handle empty subject DN when only SAN is provided
-					final X500Name userDN = StringUtils.isBlank(subjectDn) ? new X500Name("") : DnComponents.stringToBcX500Name(subjectDn);
-					final PKCS10CertificationRequest pkcs10 = generateCertificateRequest(
-							userDN, keyPair, keyAlg, subjectAltName);
-					final StringWriter pemout = new StringWriter();
-					JcaPEMWriter pm = new JcaPEMWriter(pemout);
-					pm.writeObject(pkcs10);
-					pm.close();
-					final String p10pem = pemout.toString();
-					JSONObject param = new JSONObject();
-					param.put("certificate_request", p10pem);
-					param.put("certificate_profile_name", certificateProfileName);
-					param.put("end_entity_profile_name", endEntityProfileName);
-					param.put("certificate_authority_name", caName);
-					param.put("username", endEntityName);
-					param.put("password", password);
-					param.put("include_chain", "false");
-					final StringWriter out = new StringWriter();
-					param.writeJSONString(out);
-					final String payload = out.toString();
-					this.payloads[i][j] = payload;
-					this.subjectDns[i][j] = subjectDn;
 				}
 				if (i == counter) {
 					log.info(((double) i) / ((double) numberOfThreads) * 100 + " % done.");
@@ -600,6 +788,244 @@ public class X509StressTestCommand extends ErceCommandBase {
 
 		// No CN found, return empty string
 		return "";
+	}
+
+	private void revokeCertificate(X509Certificate certificate, String issuerDn, String serialNumber, boolean backdateRevocation, int threadId, int iteration, String cnInfo, List<String> failures) {
+		try {
+			// Escape invalid URL characters
+			issuerDn = escapeInvalidUrlCharacters(issuerDn);
+
+			// Build revocation URL
+			StringBuilder urlBuilder = new StringBuilder()
+					.append("https://")
+					.append(getHostname())
+					.append(REVOKE_URL_PREFIX)
+					.append(issuerDn)
+					.append("/")
+					.append(serialNumber)
+					.append(REVOKE_URL_SUFFIX)
+					.append("?reason=")
+					.append(REVOCATION_REASON);
+
+			// Only add date parameter if backdating is requested
+			if (backdateRevocation) {
+				// Use the certificate's notBefore date for backdated revocation
+				OffsetDateTime date = certificate.getNotBefore().toInstant().atOffset(java.time.ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS);
+				String revocationDate = escapeInvalidUrlCharacters(date.toString());
+				urlBuilder.append("&date=").append(revocationDate);
+			}
+
+			final String revokeUrl = urlBuilder.toString();
+
+			// Create revocation request
+			JSONObject param = new JSONObject();
+			final StringWriter out = new StringWriter();
+			param.writeJSONString(out);
+			final String payload = out.toString();
+
+			final HttpPut revokeRequest = new HttpPut(revokeUrl);
+			revokeRequest.setEntity(new StringEntity(payload));
+
+			try (CloseableHttpResponse revokeResponse = performRESTAPIRequest(getSslContext(), revokeRequest)) {
+				final InputStream entityContent = revokeResponse.getEntity().getContent();
+				String responseString = IOUtils.toString(entityContent, StandardCharsets.UTF_8);
+				int statusCode = revokeResponse.getStatusLine().getStatusCode();
+
+				if (statusCode != 200 && statusCode != 201) {
+					String msgRevokeFailed = "Thread ID: " + threadId + ", Iteration: " + iteration + cnInfo
+							+ " - Revocation failed with code " + statusCode + ": " + responseString;
+					getLogger().error(msgRevokeFailed);
+					failures.add(msgRevokeFailed);
+				}
+			}
+		} catch (KeyManagementException | UnrecoverableKeyException | NoSuchAlgorithmException | KeyStoreException | IOException e) {
+			String msgRevokeError = "Thread ID: " + threadId + ", Iteration: " + iteration + cnInfo
+					+ " - Revocation request failed: " + e.getMessage();
+			getLogger().error(msgRevokeError);
+			failures.add(msgRevokeError);
+		}
+	}
+
+	private String escapeInvalidUrlCharacters(final String urlElement) {
+		return urlElement.replace(" ", "%20").replace("+", "%2b");
+	}
+
+	/**
+	 * Save issued certificates to file
+	 */
+	private void saveCertificatesToFile(List<CertificateInfo> certificates, String filename) {
+		try (BufferedWriter writer = new BufferedWriter(new FileWriter(filename))) {
+			for (CertificateInfo cert : certificates) {
+				writer.write(cert.toString());
+				writer.newLine();
+			}
+			log.info("Saved " + certificates.size() + " certificate(s) to file: " + filename);
+		} catch (IOException e) {
+			log.error("Failed to save certificates to file " + filename + ": " + e.getMessage());
+		}
+	}
+
+	/**
+	 * Load certificates from file
+	 */
+	private List<CertificateInfo> loadCertificatesFromFile(String filename) {
+		List<CertificateInfo> certificates = new ArrayList<>();
+		try (BufferedReader reader = new BufferedReader(new FileReader(filename))) {
+			String line;
+			while ((line = reader.readLine()) != null) {
+				line = line.trim();
+				if (!line.isEmpty() && !line.startsWith("#")) {
+					CertificateInfo cert = CertificateInfo.fromString(line);
+					if (cert != null) {
+						certificates.add(cert);
+					} else {
+						log.warn("Skipping invalid line in " + filename + ": " + line);
+					}
+				}
+			}
+			log.info("Loaded " + certificates.size() + " certificate(s) from file: " + filename);
+		} catch (IOException e) {
+			log.error("Failed to load certificates from file " + filename + ": " + e.getMessage());
+		}
+		return certificates;
+	}
+
+	/**
+	 * Perform bulk revocation of certificates from file
+	 */
+	private CommandResult performBulkRevocation(String filename, boolean backdateRevocation, int numberOfThreads) {
+		log.info("Starting bulk revocation from file: " + filename);
+
+		// Load certificates from file
+		List<CertificateInfo> certificates = loadCertificatesFromFile(filename);
+		if (certificates.isEmpty()) {
+			log.error("No certificates found in file: " + filename);
+			return CommandResult.CLI_FAILURE;
+		}
+
+		log.info("Loaded " + certificates.size() + " certificate(s) for revocation");
+		log.info("Using " + numberOfThreads + " thread(s) for parallel revocation");
+
+		// Split certificates across threads
+		int certsPerThread = (int) Math.ceil((double) certificates.size() / numberOfThreads);
+
+		log.info("\nWeapons free. Fire for effect (revocation only).");
+		long startTime = System.currentTimeMillis();
+
+		List<CompletableFuture<List<String>>> futures = new ArrayList<>();
+		for (int threadNumber = 0; threadNumber < numberOfThreads; threadNumber++) {
+			final int startIdx = threadNumber * certsPerThread;
+			final int endIdx = Math.min(startIdx + certsPerThread, certificates.size());
+
+			if (startIdx >= certificates.size()) {
+				break; // No more certificates to process
+			}
+
+			final List<CertificateInfo> threadCerts = certificates.subList(startIdx, endIdx);
+			final int threadId = threadNumber;
+
+			futures.add(CompletableFuture.supplyAsync(() -> {
+				List<String> revocationFailures = new ArrayList<>();
+
+				for (int i = 0; i < threadCerts.size(); i++) {
+					CertificateInfo cert = threadCerts.get(i);
+					String issuerDnEscaped = escapeInvalidUrlCharacters(cert.issuerDn);
+
+					// Build revocation URL
+					StringBuilder urlBuilder = new StringBuilder()
+						.append("https://").append(getHostname())
+						.append("/ejbca/ejbca-rest-api/v1/certificate/")
+						.append(issuerDnEscaped).append("/")
+						.append(cert.serialNumber).append("/revoke")
+						.append("?reason=UNSPECIFIED");
+
+					// Add date parameter only if backdating is requested
+					if (backdateRevocation) {
+						// For bulk revocation, we don't have the certificate's notBefore date
+						// So we'll use current time if backdating is requested (user should handle this carefully)
+						OffsetDateTime date = OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+						String dateStr = escapeInvalidUrlCharacters(date.toString());
+						urlBuilder.append("&date=").append(dateStr);
+					}
+
+					String restUrl = urlBuilder.toString();
+
+					try {
+						JSONObject param = new JSONObject();
+						final StringWriter out = new StringWriter();
+						param.writeJSONString(out);
+						final String payload = out.toString();
+
+						final HttpPut request = new HttpPut(restUrl);
+						request.setEntity(new StringEntity(payload));
+
+						try (CloseableHttpResponse response = performRESTAPIRequest(getSslContext(), request)) {
+							final InputStream entityContent = response.getEntity().getContent();
+							String responseString = IOUtils.toString(entityContent, StandardCharsets.UTF_8);
+
+							int statusCode = response.getStatusLine().getStatusCode();
+							if (statusCode != 200 && statusCode != 201) {
+								String errorMsg = "Thread ID: " + threadId + ", Index: " + i +
+									", SN=" + cert.serialNumber + " - Revocation failed with code " +
+									statusCode + ": " + responseString;
+								revocationFailures.add(errorMsg);
+								log.error(errorMsg);
+							}
+						}
+					} catch (Exception e) {
+						String errorMsg = "Thread ID: " + threadId + ", Index: " + i +
+							", SN=" + cert.serialNumber + " - Revocation failed with exception: " + e.getMessage();
+						revocationFailures.add(errorMsg);
+						log.error(errorMsg);
+					}
+				}
+
+				return revocationFailures;
+			}));
+		}
+
+		// Wait for all threads to complete
+		CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(CompletableFuture<?>[]::new));
+		List<String> allRevocationFailures = new ArrayList<>();
+
+		allFutures.thenRun(() -> {
+			for (CompletableFuture<List<String>> completedFuture : futures) {
+				try {
+					List<String> failures = completedFuture.get();
+					allRevocationFailures.addAll(failures);
+				} catch (ExecutionException | InterruptedException e) {
+					log.error("Future could not execute.", e);
+				}
+			}
+		});
+
+		allFutures.join();
+		long endTime = System.currentTimeMillis();
+		log.info("Fire mission complete. Weapons hold.\n");
+
+		// Print failures if any
+		if (!allRevocationFailures.isEmpty()) {
+			log.info("The following certificates failed to revoke:");
+			for (String error : allRevocationFailures) {
+				log.info(error);
+			}
+		}
+
+		// Print statistics
+		long totalCerts = certificates.size();
+		long successfulRevocations = totalCerts - allRevocationFailures.size();
+		double executionTime = (endTime - startTime) / 1000.0;
+
+		log.info("Total execution time: " + executionTime + " seconds.");
+		if (successfulRevocations > 0) {
+			double averageTime = executionTime / successfulRevocations;
+			log.info("Average revocation time: " + averageTime + " seconds.");
+			log.info("Throughput: " + (1 / averageTime) + " certificates revoked per second.");
+		}
+		log.info(successfulRevocations + " certificates were successfully revoked, with " +
+			allRevocationFailures.size() + " revocation failures.");
+
+		return CommandResult.SUCCESS;
 	}
 
 

--- a/src/main/java/com/keyfactor/ejbca/client/stress/X509StressTestCommand.java
+++ b/src/main/java/com/keyfactor/ejbca/client/stress/X509StressTestCommand.java
@@ -30,10 +30,12 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
+import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -1074,7 +1076,7 @@ public class X509StressTestCommand extends ErceCommandBase {
 			double throughput = executionTime > 0 ? successfulIssuances / executionTime : 0;
 
 			// Write data row
-			String timestamp = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
+			String timestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
 			if (includeRevocation) {
 				writer.write(String.format("%.2f,%d,%d,%d,%.2f,%d,%d,%s",
 						executionTime, totalCerts, successfulIssuances, issuanceFailures, throughput,
@@ -1094,7 +1096,7 @@ public class X509StressTestCommand extends ErceCommandBase {
 			long successfulRevocations, long revocationFailures, long duration, boolean includeRevocation) throws IOException {
 		double executionTime = duration / 1000.0;
 		double throughput = executionTime > 0 ? successfulIssuances / executionTime : 0;
-		String timestamp = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
+		String timestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
 
 		try (BufferedWriter writer = new BufferedWriter(new FileWriter(filename))) {
 			writer.write("# X509 Stress Test Results");
@@ -1167,7 +1169,7 @@ public class X509StressTestCommand extends ErceCommandBase {
 			double throughput = executionTime > 0 ? successfulRevocations / executionTime : 0;
 
 			// Write data row
-			String timestamp = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
+			String timestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
 			writer.write(String.format("%.2f,%d,%d,%d,%.2f,%s",
 					executionTime, totalCerts, successfulRevocations, revocationFailures, throughput, timestamp));
 			writer.newLine();
@@ -1181,7 +1183,7 @@ public class X509StressTestCommand extends ErceCommandBase {
 			long revocationFailures, long duration) throws IOException {
 		double executionTime = duration / 1000.0;
 		double throughput = executionTime > 0 ? successfulRevocations / executionTime : 0;
-		String timestamp = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
+		String timestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
 
 		try (BufferedWriter writer = new BufferedWriter(new FileWriter(filename))) {
 			writer.write("# X509 Bulk Revocation Test Results");

--- a/src/main/java/com/keyfactor/ejbca/client/stress/X509StressTestCommand.java
+++ b/src/main/java/com/keyfactor/ejbca/client/stress/X509StressTestCommand.java
@@ -111,6 +111,9 @@ public class X509StressTestCommand extends ErceCommandBase {
 	private static final String BACKDATEREVOKE_ARG = "--backdaterevoke";
 	private static final String SAVECERTS_ARG = "--savecerts";
 	private static final String REVOKEFILE_ARG = "--revokefile";
+	private static final String OUTPUT_FORMAT_ARG = "--outputformat";
+	private static final String OUTPUT_FILE_ARG = "--outputfile";
+	private static final String PROGRESS_INTERVAL_ARG = "--progressinterval";
 
 	private static final Set<String> RSA_KEY_SIZES = new LinkedHashSet<>(
 			Arrays.asList("1024", "1536", "2048", "3072", "4096", "6144", "8192"));
@@ -118,6 +121,14 @@ public class X509StressTestCommand extends ErceCommandBase {
 
 	private String[][] payloads;
 	private String[][] subjectDns;
+
+	// Volatile counters for real-time progress tracking
+	private volatile long totalIssuanceAttempts = 0;
+	private volatile long totalSuccessfulIssuances = 0;
+	private volatile long totalFailedIssuances = 0;
+	private volatile long totalSuccessfulRevocations = 0;
+	private volatile long totalFailedRevocations = 0;
+	private volatile boolean stopProgressTracking = false;
 
 	// Inner class to hold stress test results
 	private static class StressTestResult {
@@ -208,11 +219,50 @@ public class X509StressTestCommand extends ErceCommandBase {
 				ParameterMode.ARGUMENT, "Save issued certificate information (serial number and issuer DN) to specified file for later bulk revocation."));
 		registerParameter(new Parameter(REVOKEFILE_ARG, "filename", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
 				ParameterMode.ARGUMENT, "Perform bulk revocation of certificates listed in the specified file (created with --savecerts). When this flag is used, no new certificates are issued."));
+		registerParameter(new Parameter(OUTPUT_FORMAT_ARG, "Output format", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+				ParameterMode.ARGUMENT, "Output format for test results. Options: 'console' (default), 'csv', 'markdown'. When csv or markdown is specified, --outputfile is required."));
+		registerParameter(new Parameter(OUTPUT_FILE_ARG, "Output file", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+				ParameterMode.ARGUMENT, "File path to save test results in CSV or Markdown format. Required when --outputformat is csv or markdown."));
+		registerParameter(new Parameter(PROGRESS_INTERVAL_ARG, "Progress interval (seconds)", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+				ParameterMode.ARGUMENT, "Interval in seconds for displaying real-time progress updates. Default: 5 seconds. Set to 0 to disable progress updates."));
 
 	}
 
 	@Override
 	protected CommandResult execute(ParameterContainer parameters) {
+		// Parse output format parameters (before mode check, needed for both modes)
+		final String outputFormat = parameters.get(OUTPUT_FORMAT_ARG) != null ? parameters.get(OUTPUT_FORMAT_ARG) : "console";
+		final String outputFile = parameters.get(OUTPUT_FILE_ARG);
+
+		// Validate output format
+		if (!outputFormat.equals("console") && !outputFormat.equals("csv") && !outputFormat.equals("markdown")) {
+			log.error("Invalid output format: " + outputFormat + ". Must be 'console', 'csv', or 'markdown'");
+			return CommandResult.CLI_FAILURE;
+		}
+
+		// Validate that outputFile is provided if format is csv or markdown
+		if ((outputFormat.equals("csv") || outputFormat.equals("markdown")) && outputFile == null) {
+			log.error("--outputfile is required when --outputformat is '" + outputFormat + "'");
+			return CommandResult.CLI_FAILURE;
+		}
+
+		// Parse progress interval
+		final int progressInterval;
+		if (parameters.get(PROGRESS_INTERVAL_ARG) != null) {
+			try {
+				progressInterval = Integer.valueOf(parameters.get(PROGRESS_INTERVAL_ARG));
+			} catch (NumberFormatException e) {
+				log.error(PROGRESS_INTERVAL_ARG + " was not a numeric value");
+				return CommandResult.CLI_FAILURE;
+			}
+			if (progressInterval < 0) {
+				log.error(PROGRESS_INTERVAL_ARG + " must be non-negative");
+				return CommandResult.CLI_FAILURE;
+			}
+		} else {
+			progressInterval = 5; // Default: 5 seconds
+		}
+
 		// Check if running in bulk revocation mode
 		final String revokeFile = parameters.get(REVOKEFILE_ARG);
 		final boolean isBulkRevocationMode = !StringUtils.isBlank(revokeFile);
@@ -256,7 +306,7 @@ public class X509StressTestCommand extends ErceCommandBase {
 
 		// If --revokefile is specified, perform bulk revocation instead of enrollment
 		if (isBulkRevocationMode) {
-			return performBulkRevocation(revokeFile, backdateRevocation, numberOfThreads);
+			return performBulkRevocation(revokeFile, backdateRevocation, numberOfThreads, outputFormat, outputFile, progressInterval);
 		}
 
 		// Below this point: enrollment mode only
@@ -395,6 +445,58 @@ public class X509StressTestCommand extends ErceCommandBase {
 		// Calculate total payloads per thread considering history certificates
 		final int certsPerEntity = 1 + historyCount;
 		final int totalPayloadsPerThread = requestPerThread * certsPerEntity;
+		final long expectedTotalCerts = (long) numberOfThreads * requestPerThread * certsPerEntity;
+
+		// Reset counters
+		totalIssuanceAttempts = 0;
+		totalSuccessfulIssuances = 0;
+		totalFailedIssuances = 0;
+		totalSuccessfulRevocations = 0;
+		totalFailedRevocations = 0;
+		stopProgressTracking = false;
+
+		// Start progress tracking thread if enabled
+		Thread progressThread = null;
+		if (progressInterval > 0) {
+			progressThread = new Thread(() -> {
+				long lastAttempts = 0;
+				long lastTime = System.currentTimeMillis();
+
+				while (!stopProgressTracking) {
+					try {
+						Thread.sleep(progressInterval * 1000L);
+
+						if (stopProgressTracking) {
+							break;
+						}
+
+						long currentTime = System.currentTimeMillis();
+						long currentAttempts = totalIssuanceAttempts;
+						long intervalAttempts = currentAttempts - lastAttempts;
+						double intervalSeconds = (currentTime - lastTime) / 1000.0;
+						double certsPerSec = intervalSeconds > 0 ? intervalAttempts / intervalSeconds : 0;
+
+						if (revokeAfterIssuance) {
+							System.out.println(String.format("Progress: %d/%d certs (%d successful, %d failed), %d revoked (%d successful, %d failed) - %.2f certs/s",
+									currentAttempts, expectedTotalCerts, totalSuccessfulIssuances, totalFailedIssuances,
+									totalSuccessfulRevocations + totalFailedRevocations, totalSuccessfulRevocations, totalFailedRevocations,
+									certsPerSec));
+						} else {
+							System.out.println(String.format("Progress: %d/%d certs (%d successful, %d failed) - %.2f certs/s",
+									currentAttempts, expectedTotalCerts, totalSuccessfulIssuances, totalFailedIssuances, certsPerSec));
+						}
+
+						lastAttempts = currentAttempts;
+						lastTime = currentTime;
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						break;
+					}
+				}
+			});
+			progressThread.setDaemon(true);
+			progressThread.start();
+		}
 
 		long startTime = System.currentTimeMillis();
 		List<CompletableFuture<StressTestResult>> futures = new ArrayList<>();
@@ -410,6 +512,12 @@ public class X509StressTestCommand extends ErceCommandBase {
 					String certSubjectDn = subjectDns[row][i];
 					String cnInfo = extractCNForErrorMessage(certSubjectDn);
 					final HttpPost request = new HttpPost(restUrl);
+
+					// Increment attempt counter
+					synchronized (X509StressTestCommand.this) {
+						totalIssuanceAttempts++;
+					}
+
 					try {
 						request.setEntity(new StringEntity(payload));
 						// connect to EJBCA and send the CSR and get an issued certificate back
@@ -421,6 +529,9 @@ public class X509StressTestCommand extends ErceCommandBase {
 								String msg404 =  "Thread ID: " + row + ", Iteration: " + i + cnInfo + " - Return code was: 404: " + responseString;
 								getLogger().error(msg404);
 								issuanceFailures.add(msg404);
+								synchronized (X509StressTestCommand.this) {
+									totalFailedIssuances++;
+								}
 								break;
 							case 200:
 							case 201:
@@ -437,6 +548,11 @@ public class X509StressTestCommand extends ErceCommandBase {
 									String issuerDn = CertTools.getIssuerDN(certificate);
 									issuedCertificates.add(new CertificateInfo(serialNumber, issuerDn));
 
+									// Increment successful issuance counter
+									synchronized (X509StressTestCommand.this) {
+										totalSuccessfulIssuances++;
+									}
+
 									// Revoke if requested
 									if (revokeAfterIssuance) {
 										revokeCertificate(certificate, issuerDn, serialNumber, backdateRevocation, row, i, cnInfo, revocationFailures);
@@ -445,6 +561,9 @@ public class X509StressTestCommand extends ErceCommandBase {
 									String msgParseError = "Thread ID: " + row + ", Iteration: " + i + cnInfo + " - Failed to parse certificate: " + e.getMessage();
 									getLogger().error(msgParseError);
 									issuanceFailures.add(msgParseError);
+									synchronized (X509StressTestCommand.this) {
+										totalFailedIssuances++;
+									}
 								}
 								break;
 							default:
@@ -452,14 +571,23 @@ public class X509StressTestCommand extends ErceCommandBase {
 										+ responseString;
 								getLogger().error(msgOthers);
 								issuanceFailures.add(msgOthers);
+								synchronized (X509StressTestCommand.this) {
+									totalFailedIssuances++;
+								}
 								break;
 							}
 						} catch (KeyManagementException | UnrecoverableKeyException | NoSuchAlgorithmException
 								| KeyStoreException e) {
 							getLogger().error("Could not perform request: " + e.getMessage());
+							synchronized (X509StressTestCommand.this) {
+								totalFailedIssuances++;
+							}
 						}
 					} catch (IOException e) {
 						getLogger().error("Could not perform request: " + e.getMessage());
+						synchronized (X509StressTestCommand.this) {
+							totalFailedIssuances++;
+						}
 					}
 				}
 				return new StressTestResult(issuanceFailures, revocationFailures, issuedCertificates);
@@ -485,6 +613,10 @@ public class X509StressTestCommand extends ErceCommandBase {
 
 		allFutures.join();
 		long endTime = System.currentTimeMillis();
+
+		// Stop progress tracking
+		stopProgressTracking = true;
+
 		log.info("Fire mission complete. Weapons hold.\n");
 
 		if(!issuanceResults.isEmpty()) {
@@ -505,7 +637,8 @@ public class X509StressTestCommand extends ErceCommandBase {
 		long totalCerts = numberOfThreads * requestPerThread * certsPerEntityFinal;
 		long totalEntities = numberOfThreads * requestPerThread;
 		long successfulIssuances = totalCerts - issuanceResults.size();
-		double executionTime =  (endTime - startTime)/1000;
+		long duration = endTime - startTime;
+		double executionTime =  duration / 1000.0;
 		log.info("Total execution time: " + executionTime + " seconds.");
 		if(successfulIssuances > 0) {
 			double averageTime = executionTime / successfulIssuances;
@@ -513,8 +646,9 @@ public class X509StressTestCommand extends ErceCommandBase {
 			log.info("Throughput: " + 1 / averageTime + " certificates issued per second.");
 		}
 		log.info((successfulIssuances) + " certificates were successfully issued, with " + issuanceResults.size() + " issuance failures.");
+		long successfulRevocations = 0;
 		if(revokeAfterIssuance) {
-			long successfulRevocations = successfulIssuances - revocationResults.size();
+			successfulRevocations = successfulIssuances - revocationResults.size();
 			log.info((successfulRevocations) + " certificates were successfully revoked, with " + revocationResults.size() + " revocation failures.");
 		}
 		if(historyCount > 0) {
@@ -524,6 +658,27 @@ public class X509StressTestCommand extends ErceCommandBase {
 		// Save certificates if requested
 		if (!StringUtils.isBlank(saveCertsFile) && !allIssuedCertificates.isEmpty()) {
 			saveCertificatesToFile(allIssuedCertificates, saveCertsFile);
+		}
+
+		// Write results to file if requested
+		if (outputFormat.equals("csv")) {
+			try {
+				writeIssuanceResultsToCsv(outputFile, totalCerts, successfulIssuances, issuanceResults.size(),
+						successfulRevocations, revocationResults.size(), duration, revokeAfterIssuance);
+				log.info("Results saved to " + outputFile);
+			} catch (IOException e) {
+				log.error("Failed to write CSV results to file: " + e.getMessage());
+				return CommandResult.CLI_FAILURE;
+			}
+		} else if (outputFormat.equals("markdown")) {
+			try {
+				writeIssuanceResultsToMarkdown(outputFile, totalCerts, successfulIssuances, issuanceResults.size(),
+						successfulRevocations, revocationResults.size(), duration, revokeAfterIssuance);
+				log.info("Results saved to " + outputFile);
+			} catch (IOException e) {
+				log.error("Failed to write Markdown results to file: " + e.getMessage());
+				return CommandResult.CLI_FAILURE;
+			}
 		}
 
 		return CommandResult.SUCCESS;
@@ -836,6 +991,13 @@ public class X509StressTestCommand extends ErceCommandBase {
 							+ " - Revocation failed with code " + statusCode + ": " + responseString;
 					getLogger().error(msgRevokeFailed);
 					failures.add(msgRevokeFailed);
+					synchronized (X509StressTestCommand.this) {
+						totalFailedRevocations++;
+					}
+				} else {
+					synchronized (X509StressTestCommand.this) {
+						totalSuccessfulRevocations++;
+					}
 				}
 			}
 		} catch (KeyManagementException | UnrecoverableKeyException | NoSuchAlgorithmException | KeyStoreException | IOException e) {
@@ -843,6 +1005,9 @@ public class X509StressTestCommand extends ErceCommandBase {
 					+ " - Revocation request failed: " + e.getMessage();
 			getLogger().error(msgRevokeError);
 			failures.add(msgRevokeError);
+			synchronized (X509StressTestCommand.this) {
+				totalFailedRevocations++;
+			}
 		}
 	}
 
@@ -891,9 +1056,178 @@ public class X509StressTestCommand extends ErceCommandBase {
 	}
 
 	/**
+	 * Write issuance test results to CSV file
+	 */
+	private void writeIssuanceResultsToCsv(String filename, long totalCerts, long successfulIssuances, long issuanceFailures,
+			long successfulRevocations, long revocationFailures, long duration, boolean includeRevocation) throws IOException {
+		try (BufferedWriter writer = new BufferedWriter(new FileWriter(filename))) {
+			// Write header
+			if (includeRevocation) {
+				writer.write("Test Duration (s),Total Certificates,Successful Issuances,Failed Issuances,Throughput (certs/s),Successful Revocations,Failed Revocations,Timestamp");
+			} else {
+				writer.write("Test Duration (s),Total Certificates,Successful Issuances,Failed Issuances,Throughput (certs/s),Timestamp");
+			}
+			writer.newLine();
+
+			// Calculate throughput
+			double executionTime = duration / 1000.0;
+			double throughput = executionTime > 0 ? successfulIssuances / executionTime : 0;
+
+			// Write data row
+			String timestamp = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
+			if (includeRevocation) {
+				writer.write(String.format("%.2f,%d,%d,%d,%.2f,%d,%d,%s",
+						executionTime, totalCerts, successfulIssuances, issuanceFailures, throughput,
+						successfulRevocations, revocationFailures, timestamp));
+			} else {
+				writer.write(String.format("%.2f,%d,%d,%d,%.2f,%s",
+						executionTime, totalCerts, successfulIssuances, issuanceFailures, throughput, timestamp));
+			}
+			writer.newLine();
+		}
+	}
+
+	/**
+	 * Write issuance test results to Markdown file
+	 */
+	private void writeIssuanceResultsToMarkdown(String filename, long totalCerts, long successfulIssuances, long issuanceFailures,
+			long successfulRevocations, long revocationFailures, long duration, boolean includeRevocation) throws IOException {
+		double executionTime = duration / 1000.0;
+		double throughput = executionTime > 0 ? successfulIssuances / executionTime : 0;
+		String timestamp = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
+
+		try (BufferedWriter writer = new BufferedWriter(new FileWriter(filename))) {
+			writer.write("# X509 Stress Test Results");
+			writer.newLine();
+			writer.newLine();
+			writer.write("**Generated:** " + timestamp);
+			writer.newLine();
+			writer.newLine();
+
+			// Test Configuration section
+			writer.write("## Test Configuration");
+			writer.newLine();
+			writer.newLine();
+			writer.write("| Metric | Value |");
+			writer.newLine();
+			writer.write("|--------|-------|");
+			writer.newLine();
+			writer.write(String.format("| Test Duration | %.2f seconds |", executionTime));
+			writer.newLine();
+			writer.newLine();
+
+			// Issuance Metrics table
+			writer.write("## Issuance Metrics");
+			writer.newLine();
+			writer.newLine();
+			writer.write("| Metric | Value |");
+			writer.newLine();
+			writer.write("|--------|-------|");
+			writer.newLine();
+			writer.write(String.format("| Total Certificates | %,d |", totalCerts));
+			writer.newLine();
+			writer.write(String.format("| Successful Issuances | %,d |", successfulIssuances));
+			writer.newLine();
+			writer.write(String.format("| Failed Issuances | %,d |", issuanceFailures));
+			writer.newLine();
+			writer.write(String.format("| Throughput | %.2f certs/s |", throughput));
+			writer.newLine();
+			writer.newLine();
+
+			// Revocation Metrics table (if revocation was performed)
+			if (includeRevocation) {
+				writer.write("## Revocation Metrics");
+				writer.newLine();
+				writer.newLine();
+				writer.write("| Metric | Value |");
+				writer.newLine();
+				writer.write("|--------|-------|");
+				writer.newLine();
+				writer.write(String.format("| Successful Revocations | %,d |", successfulRevocations));
+				writer.newLine();
+				writer.write(String.format("| Failed Revocations | %,d |", revocationFailures));
+				writer.newLine();
+				writer.newLine();
+			}
+		}
+	}
+
+	/**
+	 * Write bulk revocation test results to CSV file
+	 */
+	private void writeRevocationResultsToCsv(String filename, long totalCerts, long successfulRevocations,
+			long revocationFailures, long duration) throws IOException {
+		try (BufferedWriter writer = new BufferedWriter(new FileWriter(filename))) {
+			// Write header
+			writer.write("Test Duration (s),Total Certificates,Successful Revocations,Failed Revocations,Throughput (certs/s),Timestamp");
+			writer.newLine();
+
+			// Calculate throughput
+			double executionTime = duration / 1000.0;
+			double throughput = executionTime > 0 ? successfulRevocations / executionTime : 0;
+
+			// Write data row
+			String timestamp = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
+			writer.write(String.format("%.2f,%d,%d,%d,%.2f,%s",
+					executionTime, totalCerts, successfulRevocations, revocationFailures, throughput, timestamp));
+			writer.newLine();
+		}
+	}
+
+	/**
+	 * Write bulk revocation test results to Markdown file
+	 */
+	private void writeRevocationResultsToMarkdown(String filename, long totalCerts, long successfulRevocations,
+			long revocationFailures, long duration) throws IOException {
+		double executionTime = duration / 1000.0;
+		double throughput = executionTime > 0 ? successfulRevocations / executionTime : 0;
+		String timestamp = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.Date());
+
+		try (BufferedWriter writer = new BufferedWriter(new FileWriter(filename))) {
+			writer.write("# X509 Bulk Revocation Test Results");
+			writer.newLine();
+			writer.newLine();
+			writer.write("**Generated:** " + timestamp);
+			writer.newLine();
+			writer.newLine();
+
+			// Test Configuration section
+			writer.write("## Test Configuration");
+			writer.newLine();
+			writer.newLine();
+			writer.write("| Metric | Value |");
+			writer.newLine();
+			writer.write("|--------|-------|");
+			writer.newLine();
+			writer.write(String.format("| Test Duration | %.2f seconds |", executionTime));
+			writer.newLine();
+			writer.newLine();
+
+			// Revocation Metrics table
+			writer.write("## Revocation Metrics");
+			writer.newLine();
+			writer.newLine();
+			writer.write("| Metric | Value |");
+			writer.newLine();
+			writer.write("|--------|-------|");
+			writer.newLine();
+			writer.write(String.format("| Total Certificates | %,d |", totalCerts));
+			writer.newLine();
+			writer.write(String.format("| Successful Revocations | %,d |", successfulRevocations));
+			writer.newLine();
+			writer.write(String.format("| Failed Revocations | %,d |", revocationFailures));
+			writer.newLine();
+			writer.write(String.format("| Throughput | %.2f certs/s |", throughput));
+			writer.newLine();
+			writer.newLine();
+		}
+	}
+
+	/**
 	 * Perform bulk revocation of certificates from file
 	 */
-	private CommandResult performBulkRevocation(String filename, boolean backdateRevocation, int numberOfThreads) {
+	private CommandResult performBulkRevocation(String filename, boolean backdateRevocation, int numberOfThreads,
+			String outputFormat, String outputFile, int progressInterval) {
 		log.info("Starting bulk revocation from file: " + filename);
 
 		// Load certificates from file
@@ -908,6 +1242,51 @@ public class X509StressTestCommand extends ErceCommandBase {
 
 		// Split certificates across threads
 		int certsPerThread = (int) Math.ceil((double) certificates.size() / numberOfThreads);
+		final long expectedTotalRevocations = certificates.size();
+
+		// Reset counters
+		totalIssuanceAttempts = 0;
+		totalSuccessfulIssuances = 0;
+		totalFailedIssuances = 0;
+		totalSuccessfulRevocations = 0;
+		totalFailedRevocations = 0;
+		stopProgressTracking = false;
+
+		// Start progress tracking thread if enabled
+		Thread progressThread = null;
+		if (progressInterval > 0) {
+			progressThread = new Thread(() -> {
+				long lastRevoked = 0;
+				long lastTime = System.currentTimeMillis();
+
+				while (!stopProgressTracking) {
+					try {
+						Thread.sleep(progressInterval * 1000L);
+
+						if (stopProgressTracking) {
+							break;
+						}
+
+						long currentTime = System.currentTimeMillis();
+						long currentRevoked = totalSuccessfulRevocations + totalFailedRevocations;
+						long intervalRevoked = currentRevoked - lastRevoked;
+						double intervalSeconds = (currentTime - lastTime) / 1000.0;
+						double certsPerSec = intervalSeconds > 0 ? intervalRevoked / intervalSeconds : 0;
+
+						System.out.println(String.format("Progress: %d/%d certs revoked (%d successful, %d failed) - %.2f certs/s",
+								currentRevoked, expectedTotalRevocations, totalSuccessfulRevocations, totalFailedRevocations, certsPerSec));
+
+						lastRevoked = currentRevoked;
+						lastTime = currentTime;
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						break;
+					}
+				}
+			});
+			progressThread.setDaemon(true);
+			progressThread.start();
+		}
 
 		log.info("\nWeapons free. Fire for effect (revocation only).");
 		long startTime = System.currentTimeMillis();
@@ -970,6 +1349,13 @@ public class X509StressTestCommand extends ErceCommandBase {
 									statusCode + ": " + responseString;
 								revocationFailures.add(errorMsg);
 								log.error(errorMsg);
+								synchronized (X509StressTestCommand.this) {
+									totalFailedRevocations++;
+								}
+							} else {
+								synchronized (X509StressTestCommand.this) {
+									totalSuccessfulRevocations++;
+								}
 							}
 						}
 					} catch (Exception e) {
@@ -977,6 +1363,9 @@ public class X509StressTestCommand extends ErceCommandBase {
 							", SN=" + cert.serialNumber + " - Revocation failed with exception: " + e.getMessage();
 						revocationFailures.add(errorMsg);
 						log.error(errorMsg);
+						synchronized (X509StressTestCommand.this) {
+							totalFailedRevocations++;
+						}
 					}
 				}
 
@@ -1001,6 +1390,10 @@ public class X509StressTestCommand extends ErceCommandBase {
 
 		allFutures.join();
 		long endTime = System.currentTimeMillis();
+
+		// Stop progress tracking
+		stopProgressTracking = true;
+
 		log.info("Fire mission complete. Weapons hold.\n");
 
 		// Print failures if any
@@ -1014,7 +1407,8 @@ public class X509StressTestCommand extends ErceCommandBase {
 		// Print statistics
 		long totalCerts = certificates.size();
 		long successfulRevocations = totalCerts - allRevocationFailures.size();
-		double executionTime = (endTime - startTime) / 1000.0;
+		long duration = endTime - startTime;
+		double executionTime = duration / 1000.0;
 
 		log.info("Total execution time: " + executionTime + " seconds.");
 		if (successfulRevocations > 0) {
@@ -1024,6 +1418,27 @@ public class X509StressTestCommand extends ErceCommandBase {
 		}
 		log.info(successfulRevocations + " certificates were successfully revoked, with " +
 			allRevocationFailures.size() + " revocation failures.");
+
+		// Write results to file if requested
+		if (outputFormat.equals("csv")) {
+			try {
+				writeRevocationResultsToCsv(outputFile, totalCerts, successfulRevocations,
+						allRevocationFailures.size(), duration);
+				log.info("Results saved to " + outputFile);
+			} catch (IOException e) {
+				log.error("Failed to write CSV results to file: " + e.getMessage());
+				return CommandResult.CLI_FAILURE;
+			}
+		} else if (outputFormat.equals("markdown")) {
+			try {
+				writeRevocationResultsToMarkdown(outputFile, totalCerts, successfulRevocations,
+						allRevocationFailures.size(), duration);
+				log.info("Results saved to " + outputFile);
+			} catch (IOException e) {
+				log.error("Failed to write Markdown results to file: " + e.getMessage());
+				return CommandResult.CLI_FAILURE;
+			}
+		}
 
 		return CommandResult.SUCCESS;
 	}

--- a/src/main/java/com/keyfactor/ejbca/client/stress/X509StressTestCommand.java
+++ b/src/main/java/com/keyfactor/ejbca/client/stress/X509StressTestCommand.java
@@ -38,7 +38,15 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.log4j.Logger;
+import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.DERSet;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.ExtensionsGenerator;
+import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.operator.OperatorCreationException;
@@ -80,12 +88,15 @@ public class X509StressTestCommand extends ErceCommandBase {
 	private static final String POSTFIX_ARG = "--postfix";
 	private static final String KEYALG_ARG = "--keyalg";
 	private static final String KEYSPEC_ARG = "--keyspec";
+	private static final String SUBJECTDN_ARG = "--subjectdn";
+	private static final String SAN_ARG = "--san";
 
 	private static final Set<String> RSA_KEY_SIZES = new LinkedHashSet<>(
 			Arrays.asList("1024", "1536", "2048", "3072", "4096", "6144", "8192"));
 	private static final Set<String> EC_CURVES = AlgorithmTools.getOnlyNamedEcCurvesMap().keySet();
 
 	private String[][] payloads;
+	private String[][] subjectDns;
 
 	{
 		registerParameter(new Parameter(CA_ARG, "CA Name", MandatoryMode.MANDATORY, StandaloneMode.FORBID,
@@ -123,6 +134,10 @@ public class X509StressTestCommand extends ErceCommandBase {
 				ParameterMode.ARGUMENT,
 				"Key Specification.\n If cipher was RSA, must be one of [ 1024, 1536, 2048, 3072, 4096, 6144, 8192 ]. Default is 2048.\n If cipher was EC/ECDSA, must be one of "
 						+ ecCurvesFormatted + ". Default is secp256r1.\n Should be omitted for ML-DSA variants."));
+		registerParameter(new Parameter(SUBJECTDN_ARG, "Subject DN", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+				ParameterMode.ARGUMENT, "Optional Subject DN for certificates. If a CN attribute is present, the prefix and postfix will be applied to it. Default is 'CN=<prefix>_<threadId>_<certId>_<postfix>'."));
+		registerParameter(new Parameter(SAN_ARG, "Subject Alternative Name", MandatoryMode.OPTIONAL, StandaloneMode.FORBID,
+				ParameterMode.ARGUMENT, "Optional Subject Alternative Name (SAN) for certificates. Format: 'dnsName=example.com' or 'dnsName=example.com,ipAddress=192.168.1.1'. If a dnsName is provided, the prefix and postfix will be applied to it."));
 
 	}
 
@@ -142,6 +157,20 @@ public class X509StressTestCommand extends ErceCommandBase {
 			postfix = parameters.get(POSTFIX_ARG);
 		} else {
 			postfix = "";
+		}
+
+		final String subjectDn;
+		if(parameters.containsKey(SUBJECTDN_ARG)) {
+			subjectDn = parameters.get(SUBJECTDN_ARG);
+		} else {
+			subjectDn = null;
+		}
+
+		final String subjectAltName;
+		if(parameters.containsKey(SAN_ARG)) {
+			subjectAltName = parameters.get(SAN_ARG);
+		} else {
+			subjectAltName = null;
 		}
 
 		// Parse and validate key algorithm
@@ -226,7 +255,7 @@ public class X509StressTestCommand extends ErceCommandBase {
 		
 		final boolean singleKey = parameters.containsKey(REUSE_KEY_ARG);
 
-		generatePayloads(numberOfThreads, requestPerThread, caName, certificateProfileName, endEntityProfileName, singleKey, prefix, postfix, keyAlg, keySpec);
+		generatePayloads(numberOfThreads, requestPerThread, caName, certificateProfileName, endEntityProfileName, singleKey, prefix, postfix, keyAlg, keySpec, subjectDn, subjectAltName);
 		log.info("All CSR payloads transferred to caches..\n\nPreparing orbital bombardment in....");
 		try {
 			for (int i = 3; i > 0; --i) {
@@ -244,10 +273,12 @@ public class X509StressTestCommand extends ErceCommandBase {
 		for (int threadNumber = 0; threadNumber < numberOfThreads; ++threadNumber) {
 			final int row = threadNumber;
 			futures.add(CompletableFuture.supplyAsync(() -> {
-				
+
 				List<String> failures = new ArrayList<>();
 				for (int i = 0; i < requestPerThread; ++i) {
 					String payload = payloads[row][i];
+					String certSubjectDn = subjectDns[row][i];
+					String cnInfo = extractCNForErrorMessage(certSubjectDn);
 					final HttpPost request = new HttpPost(restUrl);
 					try {
 						request.setEntity(new StringEntity(payload));
@@ -257,7 +288,7 @@ public class X509StressTestCommand extends ErceCommandBase {
 							String responseString = IOUtils.toString(entityContent, StandardCharsets.UTF_8);
 							switch (response.getStatusLine().getStatusCode()) {
 							case 404:
-								String msg404 =  "Thread ID: " + row + ", Iteration: " + i + " - Return code was: 404: " + responseString;
+								String msg404 =  "Thread ID: " + row + ", Iteration: " + i + cnInfo + " - Return code was: 404: " + responseString;
 								getLogger().error(msg404);
 								failures.add(msg404);
 								break;
@@ -266,7 +297,7 @@ public class X509StressTestCommand extends ErceCommandBase {
 								// Do nothing.
 								break;
 							default:
-								String msgOthers = "Thread ID: " + row + ", Iteration: " + i + " - Return code was: " + response.getStatusLine().getStatusCode() + ": "
+								String msgOthers = "Thread ID: " + row + ", Iteration: " + i + cnInfo + " - Return code was: " + response.getStatusLine().getStatusCode() + ": "
 										+ responseString;
 								getLogger().error(msgOthers);
 								failures.add(msgOthers);
@@ -360,12 +391,13 @@ public class X509StressTestCommand extends ErceCommandBase {
 
 	@SuppressWarnings("unchecked")
 	private void generatePayloads(final int numberOfThreads, final int requestPerThread, final String caName,
-			final String certificateProfileName, final String endEntityProfileName, final boolean singleKey, final String prefix, final String postfix, final String keyAlg, final String keySpec) {
+			final String certificateProfileName, final String endEntityProfileName, final boolean singleKey, final String prefix, final String postfix, final String keyAlg, final String keySpec, final String customSubjectDn, final String customSubjectAltName) {
 		log.info("Will submit a total of " + requestPerThread * numberOfThreads + " CSRs, using " + numberOfThreads
 				+ " threads.");
 		log.info("Pre generating CSR payloads...");
 		final String password = "foo123";
 		this.payloads = new String[numberOfThreads][requestPerThread];
+		this.subjectDns = new String[numberOfThreads][requestPerThread];
 		final int increment = numberOfThreads / 10;
 		int counter = 0;
 		KeyPair keyPair = null;	
@@ -373,7 +405,33 @@ public class X509StressTestCommand extends ErceCommandBase {
 			for (int i = 0; i < numberOfThreads; ++i) {
 				for (int j = 0; j < requestPerThread; ++j) {
 					final String endEntityName = prefix + "_" + i + "_" + j + (StringUtils.isEmpty(postfix) ? "" : "_" + postfix);
-					final String subjectDn = "CN=" + endEntityName;
+					final String subjectDn;
+					final String subjectAltName;
+
+					if (customSubjectAltName != null) {
+						// Use custom SAN and apply prefix/postfix to dnsName if present
+						subjectAltName = applyPrefixPostfixToSAN(customSubjectAltName, prefix, postfix, i, j);
+
+						if (customSubjectDn != null) {
+							// Both SAN and DN provided: use custom DN with prefix/postfix
+							subjectDn = applyPrefixPostfixToCN(customSubjectDn, prefix, postfix, i, j);
+						} else {
+							// Only SAN provided: use empty subject DN
+							subjectDn = "";
+						}
+					} else {
+						// No SAN provided
+						subjectAltName = null;
+
+						if (customSubjectDn != null) {
+							// Only DN provided: use custom DN with prefix/postfix
+							subjectDn = applyPrefixPostfixToCN(customSubjectDn, prefix, postfix, i, j);
+						} else {
+							// Neither SAN nor DN provided: default behavior with CN
+							subjectDn = "CN=" + endEntityName;
+						}
+					}
+
 					if (keyPair == null || !singleKey) {
 						try {
 							keyPair = KeyTools.genKeys(keySpec, keyAlg);
@@ -381,8 +439,10 @@ public class X509StressTestCommand extends ErceCommandBase {
 							throw new IllegalStateException("Could not generate key pairs.", e);
 						}
 					}
+					// Handle empty subject DN when only SAN is provided
+					final X500Name userDN = StringUtils.isBlank(subjectDn) ? new X500Name("") : DnComponents.stringToBcX500Name(subjectDn);
 					final PKCS10CertificationRequest pkcs10 = generateCertificateRequest(
-							DnComponents.stringToBcX500Name(subjectDn), keyPair, keyAlg);
+							userDN, keyPair, keyAlg, subjectAltName);
 					final StringWriter pemout = new StringWriter();
 					JcaPEMWriter pm = new JcaPEMWriter(pemout);
 					pm.writeObject(pkcs10);
@@ -400,6 +460,7 @@ public class X509StressTestCommand extends ErceCommandBase {
 					param.writeJSONString(out);
 					final String payload = out.toString();
 					this.payloads[i][j] = payload;
+					this.subjectDns[i][j] = subjectDn;
 				}
 				if (i == counter) {
 					log.info(((double) i) / ((double) numberOfThreads) * 100 + " % done.");
@@ -412,7 +473,7 @@ public class X509StressTestCommand extends ErceCommandBase {
 
 	}
 
-	private static PKCS10CertificationRequest generateCertificateRequest(final X500Name userDN, final KeyPair keyPair, final String keyAlg) throws IOException {
+	private static PKCS10CertificationRequest generateCertificateRequest(final X500Name userDN, final KeyPair keyPair, final String keyAlg, final String subjectAltName) throws IOException {
 		try {
 			final PublicKey publicKey = keyPair.getPublic();
 			final String sigAlg;
@@ -441,12 +502,104 @@ public class X509StressTestCommand extends ErceCommandBase {
 				}
 			}
 
+			// Add SAN extension if provided
+			ExtensionsGenerator extensionsGenerator = new ExtensionsGenerator();
+			if (!StringUtils.isBlank(subjectAltName)) {
+				GeneralNames san = DnComponents.getGeneralNamesFromAltName(subjectAltName);
+				extensionsGenerator.addExtension(Extension.subjectAlternativeName, false, san);
+			}
+
+			DERSet attributes;
+			if (!extensionsGenerator.isEmpty()) {
+				final Extensions extensions = extensionsGenerator.generate();
+				// Add the extension(s) to the PKCS#10 request as a pkcs_9_at_extensionRequest
+				ASN1EncodableVector extensionattr = new ASN1EncodableVector();
+				extensionattr.add(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest);
+				extensionattr.add(new DERSet(extensions));
+				// Complete the Attribute section of the request, the set (Attributes) contains one sequence (Attribute)
+				ASN1EncodableVector v = new ASN1EncodableVector();
+				v.add(new DERSequence(extensionattr));
+				attributes = new DERSet(v);
+			} else {
+				attributes = new DERSet();
+			}
+
 			return CertTools.genPKCS10CertificationRequest(sigAlg, userDN,
-					publicKey, null, keyPair.getPrivate(), BouncyCastleProvider.PROVIDER_NAME);
+					publicKey, attributes, keyPair.getPrivate(), BouncyCastleProvider.PROVIDER_NAME);
 		} catch (OperatorCreationException e) {
 			throw new IllegalStateException("Unable to generate CSR.", e);
 		}
 
+	}
+
+	private String applyPrefixPostfixToCN(final String subjectDn, final String prefix, final String postfix, final int threadId, final int certId) {
+		// Parse the subject DN to find CN attribute
+		String[] parts = subjectDn.split(",");
+		StringBuilder result = new StringBuilder();
+
+		for (int i = 0; i < parts.length; i++) {
+			String part = parts[i].trim();
+			if (part.toUpperCase().startsWith("CN=")) {
+				// Extract the CN value
+				String cnValue = part.substring(3).trim();
+				// Apply prefix and postfix
+				String modifiedCN = "CN=" + prefix + "_" + cnValue + "_" + threadId + "_" + certId + (StringUtils.isEmpty(postfix) ? "" : "_" + postfix);
+				result.append(modifiedCN);
+			} else {
+				result.append(part);
+			}
+
+			if (i < parts.length - 1) {
+				result.append(",");
+			}
+		}
+
+		return result.toString();
+	}
+
+	private String applyPrefixPostfixToSAN(final String subjectAltName, final String prefix, final String postfix, final int threadId, final int certId) {
+		// Parse the SAN to find dnsName attributes and apply prefix/postfix
+		String[] parts = subjectAltName.split(",");
+		StringBuilder result = new StringBuilder();
+
+		for (int i = 0; i < parts.length; i++) {
+			String part = parts[i].trim();
+			if (part.toLowerCase().startsWith("dnsname=")) {
+				// Extract the dnsName value
+				String dnsValue = part.substring(8).trim();
+				// Apply prefix and postfix to DNS name
+				String modifiedDNS = "dnsName=" + prefix + "_" + dnsValue + "_" + threadId + "_" + certId + (StringUtils.isEmpty(postfix) ? "" : "_" + postfix);
+				result.append(modifiedDNS);
+			} else {
+				// Keep other SAN types unchanged (ipAddress, email, etc.)
+				result.append(part);
+			}
+
+			if (i < parts.length - 1) {
+				result.append(",");
+			}
+		}
+
+		return result.toString();
+	}
+
+	private String extractCNForErrorMessage(final String subjectDn) {
+		// Extract CN from subject DN for error messages
+		if (StringUtils.isBlank(subjectDn)) {
+			return "";
+		}
+
+		String[] parts = subjectDn.split(",");
+		for (String part : parts) {
+			String trimmedPart = part.trim();
+			if (trimmedPart.toUpperCase().startsWith("CN=")) {
+				// Extract the CN value and return in the format ", CN=value"
+				return ", " + trimmedPart;
+			}
+		}
+
+		// No CN found, return empty string
+		return "";
 	}
 
 

--- a/src/main/resources/META-INF/services/org.ejbca.ui.cli.infrastructure.command.CliCommandPlugin
+++ b/src/main/resources/META-INF/services/org.ejbca.ui.cli.infrastructure.command.CliCommandPlugin
@@ -10,6 +10,7 @@ com.keyfactor.ejbca.client.configdump.ConfigDumpImportCommand
 com.keyfactor.ejbca.client.enroll.EnrollGenKeysCommand
 com.keyfactor.ejbca.client.enroll.EnrollWithKeypairCommand
 com.keyfactor.ejbca.client.stress.X509StressTestCommand
+com.keyfactor.ejbca.client.stress.OcspStressTestCommand
 com.keyfactor.ejbca.client.GetStatusCommand
 com.keyfactor.ejbca.client.RevokeCommand
 


### PR DESCRIPTION
# EJBCA Easy REST Client - Feature Summary

This document outlines all the features and changes made to the EJBCA Easy REST Client stress testing commands.

---

# OCSP Stress Test Command

## Overview
The OCSP Stress Test Command (`ocspstress`) provides multi-threaded OCSP (Online Certificate Status Protocol) stress testing capabilities against OCSP responders. It enables performance testing of OCSP infrastructure by sending concurrent requests and measuring response times and certificate status distribution.

**File:** `/Users/srajala/git/ejbca-easy-rest-client/src/main/java/com/keyfactor/ejbca/client/stress/OcspStressTestCommand.java`

## Features

### 1. Multi-threaded OCSP Requests
Sends concurrent OCSP status lookup requests using a configurable number of threads to test OCSP responder performance under load.

**Usage:**
```bash
ocspstress --ocspurl "http://myhost:8080/ejbca/publicweb/status/ocsp" \
  --ocspsnfile serial_numbers.txt \
  --cacertfile ca.pem \
  --threads 10 \
  --waittime 100
```

**Parameters:**
- `--ocspurl`: OCSP responder URL (mandatory)
- `--ocspsnfile`: Serial number file (mandatory, two formats supported)
- `--cacertfile`: PEM-encoded CA certificate file (mandatory)
- `--threads`: Number of concurrent threads (mandatory)
- `--waittime`: Milliseconds to wait between requests per thread (mandatory)

### 2. Dual Serial Number File Format Support
Supports two input file formats for maximum flexibility:

**Format 1: Simple serial number list**
```
12345678
0xABCDEF123456
987654321
```
- One serial number per line
- Supports decimal or hexadecimal (with `0x` prefix)
- Comments starting with `#` are ignored

**Format 2: Certificate info from --savecerts**
```
1A2B3C4D5E6F|CN=Test CA,O=Keyfactor,C=US
7G8H9I0J1K2L|CN=Test CA,O=Keyfactor,C=US
```
- Pipe-delimited format: `serialNumber|issuerDn`
- Compatible with X509StressTestCommand `--savecerts` output
- Enables seamless workflow from issuance to OCSP testing

**Implementation:** Lines 328-377 in `loadCertificateInfo()` method

### 3. HTTP Method Support
Supports multiple OCSP request types:

- **POST** (default): Standard OCSP POST request with application/ocsp-request content type
- **GET**: OCSP request encoded in URL (Base64-encoded request with proper URL encoding per RFC 6960)

**Usage:**
```bash
# POST request (default)
ocspstress --ocspurl "..." --ocspsnfile file.txt --cacertfile ca.pem --threads 5 --waittime 100

# GET request
ocspstress --ocspurl "..." --ocspsnfile file.txt --cacertfile ca.pem --threads 5 --waittime 100 --reqtype GET
```

**Implementation Details:**
- Lines 514-531 in `sendOcspRequest()` method
- GET requests use standard Base64 encoding with URL percent-encoding per RFC 6960 Section A.1.1
- Percent-encodes Base64 special characters for URL safety:
  - `+` → `%2B`
  - `/` → `%2F`
  - `=` → `%3D`
- EJBCA's OCSP servlet decodes the URL, then converts spaces back to `+` before Base64 decoding
- This encoding scheme works with both signed and unsigned OCSP requests
- Compatible with EJBCA's URL decoding logic: `URLDecoder.decode().replaceAll(" ", "+")`

**RFC 6960 Size Limitation:**
- Lines 115-125 in parameter registration
- CLI help text includes warning that GET requests longer than 255 bytes after encoding SHOULD use POST instead
- Signed OCSP requests are typically much larger than unsigned requests and may exceed this limit
- This follows RFC 6960 Section A.1 recommendation

### 4. Random Certificate Selection
Each thread randomly selects certificates from the loaded serial number list, simulating realistic OCSP lookup patterns.

**Implementation:** Lines 224-232 in `execute()` method
```java
CertificateInfo cert = certList.get(random.nextInt(certList.size()));
```

### 5. Configurable Test Duration
Control how long the stress test runs:

**Unlimited duration (default):**
```bash
ocspstress --ocspurl "..." --ocspsnfile file.txt --cacertfile ca.pem --threads 5 --waittime 100
```
Runs indefinitely until interrupted (Ctrl+C)

**Fixed duration:**
```bash
ocspstress --ocspurl "..." --ocspsnfile file.txt --cacertfile ca.pem --threads 5 --waittime 100 --duration 60
```
Runs for 60 seconds then stops automatically

**Implementation:** Lines 177-186 in `execute()` method

### 6. Nonce Extension Support
Adds OCSP nonce extension to requests for replay attack prevention.

**Default nonce length:** 32 bytes

**Custom nonce length:**
```bash
ocspstress --ocspurl "..." --ocspsnfile file.txt --cacertfile ca.pem --threads 5 --waittime 100 --ocspnoncelen 16
```

**Implementation:** Lines 391-410 in `buildOcspRequest()` method
```java
if (nonceLength > 0) {
    byte[] nonce = new byte[nonceLength];
    new SecureRandom().nextBytes(nonce);
    Extension ext = new Extension(OCSPObjectIdentifiers.id_pkix_ocsp_nonce, false,
        new DEROctetString(nonce));
    builder.setRequestExtensions(new Extensions(ext));
}
```

### 7. Random Wait Time
Optionally randomize the wait time between requests to simulate more realistic load patterns.

**Fixed wait time (default):**
```bash
ocspstress ... --waittime 100
```
Waits exactly 100ms between requests

**Random wait time:**
```bash
ocspstress ... --waittime 100 --randomwait
```
Waits between 0-100ms (random) between requests

**Implementation:** Lines 258-264 in `execute()` method
```java
int actualWait = randomWait ? random.nextInt(waitTime + 1) : waitTime;
Thread.sleep(actualWait);
```

### 8. Comprehensive Performance Metrics

The stress test collects and reports detailed performance statistics:

**Response Time Metrics:**
- Minimum response time
- Maximum response time
- Average response time
- P50 (median) response time
- P95 response time
- P99 response time

**Throughput Metrics:**
- Total requests
- Successful requests
- Failed requests
- Requests per second

**Certificate Status Distribution:**
- GOOD count
- REVOKED count
- UNKNOWN count

**Sample Output:**
```
===== OCSP Stress Test Results =====
Total execution time: 60.00 seconds
Total requests: 5000
Successful requests: 4995
Failed requests: 5
Throughput: 83.25 requests/second

Response Times (ms):
  Min: 8
  Max: 156
  Avg: 12
  P50: 11
  P95: 18
  P99: 24

Certificate Status Distribution:
  GOOD: 4500
  REVOKED: 450
  UNKNOWN: 45
```

**Implementation:** Lines 526-576 in `reportStatistics()` method

### 9. Debug Request and Response Saving
Save OCSP requests and responses to disk for debugging and analysis using the `--saveocsp` flag.

**Usage:**
```bash
ocspstress --ocspurl "..." --ocspsnfile file.txt --cacertfile ca.pem \
  --threads 5 --waittime 100 --saveocsp /tmp/ocsp-debug
```

**Behavior:**
- Saves both OCSP requests and responses to the specified directory
- Directory is automatically created if it doesn't exist
- Request filename format: `ocsp-req-t{threadId}-r{requestNum}.der`
- Response filename format: `ocsp-resp-t{threadId}-r{requestNum}.der`
- Files saved in DER (binary ASN.1) format
- Can be analyzed with OpenSSL:
  ```bash
  openssl ocsp -reqin ocsp-req-t0-r0.der -text -noverify
  openssl ocsp -respin ocsp-resp-t0-r0.der -text -noverify
  ```
- Failures are silently ignored (doesn't affect test execution)

**Parameters:**
- `--saveocsp <directory>`: Directory path to save OCSP requests and responses (optional)

**Implementation:**
- Lines 855-868: `saveDebugRequest()` method
- Lines 870-886: `saveDebugResponse()` method
- Lines 290-304: Directory validation and creation in `execute()` method

### 10. Real-time Progress Updates
Displays live progress updates during stress test execution showing request counts, success/failure rates, and throughput.

**Usage:**
```bash
# Default 5-second interval
ocspstress --ocspurl "..." --ocspsnfile file.txt --cacertfile ca.pem \
  --threads 10 --waittime 50

# Custom 10-second interval
ocspstress --ocspurl "..." --ocspsnfile file.txt --cacertfile ca.pem \
  --threads 10 --waittime 50 --progressinterval 10

# Disable progress updates
ocspstress --ocspurl "..." --ocspsnfile file.txt --cacertfile ca.pem \
  --threads 10 --waittime 50 --progressinterval 0
```

**Behavior:**
- Progress updates display every N seconds (configurable, default 5 seconds)
- Shows current request count, successful requests, failed requests
- Displays current throughput (requests per second) based on interval
- Updates are non-blocking and run on a daemon thread
- Automatically stops when test completes or is interrupted

**Sample Output:**
```
Starting OCSP stress test with 10 threads
OCSP URL: http://localhost:8080/ocsp
Request type: POST
Wait time: 50 ms
Duration: unlimited

Progress: 834 requests (834 successful, 0 failed) - 83.40 req/s
Progress: 1671 requests (1671 successful, 0 failed) - 83.70 req/s
Progress: 2508 requests (2508 successful, 0 failed) - 83.70 req/s
```

**Parameters:**
- `--progressinterval <seconds>`: Progress update interval (default: 5 seconds, 0 to disable)

**Implementation:**
- Volatile counters for thread-safe tracking: `totalRequestsCompleted`, `totalSuccessfulRequests`, `totalFailedRequests`
- Daemon thread periodically samples counters and calculates throughput
- Synchronized blocks ensure thread-safe counter increments
- Progress thread automatically terminates on test completion

### 11. CSV/Markdown Output Formats
Export stress test results to CSV or Markdown files for automated testing and reporting.

**Usage:**
```bash
# CSV output for automated testing
ocspstress --ocspurl "..." --ocspsnfile file.txt --cacertfile ca.pem \
  --threads 10 --waittime 50 --duration 60 \
  --outputformat csv --outputfile results.csv

# Markdown output for human-readable reports
ocspstress --ocspurl "..." --ocspsnfile file.txt --cacertfile ca.pem \
  --threads 10 --waittime 50 --duration 60 \
  --outputformat markdown --outputfile results.md

# Console output (default, no file created)
ocspstress --ocspurl "..." --ocspsnfile file.txt --cacertfile ca.pem \
  --threads 10 --waittime 50 --duration 60
```

**CSV Format:**
- Single header row with column names
- Single data row with test results
- Includes timestamp for each test run
- Easy to parse and import into spreadsheets or automated systems
- Columns: Test Duration, Total Requests, Successful, Failed, Throughput, Response Times (Min/Max/Avg/P50/P95/P99), Certificate Status Counts

**Sample CSV:**
```csv
Test Duration (s),Total Requests,Successful,Failed,Throughput (req/s),Min Response (ms),Max Response (ms),Avg Response (ms),P50 (ms),P95 (ms),P99 (ms),GOOD,REVOKED,UNKNOWN,Timestamp
60.00,5000,4995,5,83.25,8,156,12,11,18,24,4500,450,45,2025-12-31 14:30:00
```

**Markdown Format:**
- Human-readable formatted tables
- Includes test configuration, performance metrics, response times, and status distribution
- Perfect for embedding in documentation or sharing with stakeholders
- Includes timestamp and all test parameters

**Sample Markdown:**
```markdown
# OCSP Stress Test Results

**Generated:** 2025-12-31 14:30:00

## Test Configuration

| Parameter | Value |
|-----------|-------|
| OCSP URL | http://localhost:8080/ocsp |
| Request Type | POST |
| Threads | 10 |
| Wait Time | 50 ms |

## Performance Metrics

| Metric | Value |
|--------|-------|
| Total Requests | 5000 |
| Successful | 4995 |
| Failed | 5 |
| Throughput | 83.25 req/s |

## Response Times

| Metric | Time (ms) |
|--------|-----------|
| Min | 8 |
| Max | 156 |
| Avg | 12 |
| P50 | 11 |
| P95 | 18 |
| P99 | 24 |

## Certificate Status Distribution

| Status | Count |
|--------|-------|
| GOOD | 4500 |
| REVOKED | 450 |
| UNKNOWN | 45 |
```

**Parameters:**
- `--outputformat <format>`: Output format - 'console' (default), 'csv', or 'markdown'
- `--outputfile <filename>`: File path to save results (required when format is csv or markdown)

**Implementation:**
- `writeResultsToCsv()` method generates CSV output
- `writeResultsToMarkdown()` method generates Markdown output with formatted tables
- Both methods use try-with-resources for safe file handling
- Validation ensures output file is specified when format requires it
- All statistics from console output are included in file outputs

### 12. HTTPS with Client Authentication
Supports mutual TLS authentication via inherited base class functionality.

**Usage:**
```bash
ocspstress --authkeystore client.p12 --authkeystorepass password123 \
  --hostname secure-ocsp.example.com:8443 \
  --ocspurl "https://secure-ocsp.example.com:8443/ocsp" \
  --ocspsnfile file.txt --cacertfile ca.pem --threads 5 --waittime 100
```

**Inherited from ErceCommandBase:** SSL context creation with mutual TLS support

## Code Organization

### Class Structure
```
ErceCommandBase (existing base class)
  └── OcspStressTestCommand (new class)
```

### Inner Classes (Lines 113-138)
- `CertificateInfo`: Stores serial number and issuer DN
- `OcspTestResult`: Aggregates failures, status counts, and response times per thread

### Key Methods
- `loadCertificateInfo()` (lines 328-377): Parse serial number files
- `loadCaCertificate()` (lines 382-396): Load CA certificate from PEM
- `buildOcspRequest()` (lines 391-410): Generate OCSP request with nonce
- `sendOcspRequest()` (lines 416-445): Send HTTP POST/GET request
- `parseOcspResponse()` (lines 450-478): Parse OCSP response and extract status
- `saveDebugRequest()` (lines 506-520): Save requests for debugging
- `reportStatistics()` (lines 526-576): Generate performance report

### Required Libraries
- **Bouncy Castle OCSP**: org.bouncycastle.cert.ocsp.*
- **Apache HttpComponents**: HTTP client for POST/GET requests
- **Java Concurrency**: CompletableFuture for multi-threading

## Usage Examples

### Example 1: Basic OCSP Stress Test
```bash
ocspstress --ocspurl "http://localhost:8080/ejbca/publicweb/status/ocsp" \
  --ocspsnfile serials.txt \
  --cacertfile myca.pem \
  --threads 10 \
  --waittime 50
```
Runs indefinitely with 10 threads, 50ms wait between requests

### Example 2: Time-Limited Test with Metrics
```bash
ocspstress --ocspurl "http://localhost:8080/ejbca/publicweb/status/ocsp" \
  --ocspsnfile serials.txt \
  --cacertfile myca.pem \
  --threads 20 \
  --waittime 100 \
  --duration 300 \
  --randomwait
```
Runs for 5 minutes with 20 threads and random wait times

### Example 3: HTTPS with Client Auth and Debug
```bash
mkdir ./ocsp-requests
ocspstress --authkeystore client.p12 --authkeystorepass secret \
  --hostname secure-ocsp.example.com:8443 \
  --ocspurl "https://secure-ocsp.example.com:8443/ocsp" \
  --ocspsnfile issued_certs.txt \
  --cacertfile ca.pem \
  --threads 5 \
  --waittime 200 \
  --duration 60 \
  --ocspnoncelen 16
```
Uses client certificate auth, saves debug requests, custom nonce length

### Example 4: Integration with X509 Stress Test
```bash
# Step 1: Issue certificates and save for OCSP testing
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 --savecerts issued_certs.txt

# Step 2: Run OCSP stress test on issued certificates
ocspstress --ocspurl "http://localhost:8080/ejbca/publicweb/status/ocsp" \
  --ocspsnfile issued_certs.txt \
  --cacertfile myca.pem \
  --threads 10 \
  --waittime 50
```
Seamless workflow from certificate issuance to OCSP testing

## Build Status
✅ **Successfully compiled and tested**

---

# X509 Stress Test Command

This document outlines all the features and changes made to the X509StressTestCommand for EJBCA stress testing.

## Features Added

### 1. Certificate Revocation After Issuance (`--revoke`)
**Line References:** 107, 158-161, 213-214, 351-360, 686-741

Automatically revokes certificates immediately after successful issuance to test revocation performance and certificate lifecycle.

**Usage:**
```bash
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 --revoke
```

**Behavior:**
- After each successful certificate issuance (200/201 response), the certificate is automatically revoked
- Parses the issued certificate from the JSON response
- Extracts serial number and issuer DN from the certificate
- Calls the EJBCA revoke API with reason "UNSPECIFIED" using current timestamp
- Reports revocation failures separately in the error log
- Useful for testing complete certificate lifecycle and revocation throughput

**Implementation:**
- `revokeCertificate()` method at lines 711-769 handles the revocation
- Uses HTTP PUT to `/ejbca/ejbca-rest-api/v1/certificate/{issuer_dn}/{serial_number}/revoke?reason=UNSPECIFIED`
- **Without `--backdaterevoke`**: URL does NOT include `date` parameter (current time used by server)
- **With `--backdaterevoke`**: URL includes `&date={notBefore}` parameter
- `escapeInvalidUrlCharacters()` helper method at lines 771-773 for URL encoding
- Revocation errors are tracked separately from issuance errors
- Statistics report both issuance and revocation success/failure counts separately
- Revocation errors don't affect issuance success count

---

### 1a. Backdated Revocation (`--backdaterevoke`)
**Line References:** 107, 160-161, 214, 354, 686-741

Allows backdating certificate revocation to the certificate's validity start date (notBefore) instead of using the current time. Must be used in conjunction with `--revoke` flag.

**Usage:**
```bash
# Revoke using certificate's notBefore date
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 --revoke --backdaterevoke
```

**Behavior:**
- When `--backdaterevoke` is set along with `--revoke`, revocation uses the certificate's notBefore date
- Useful for testing certificate profiles that allow backdated revocation
- Without `--backdaterevoke`, revocation uses current timestamp (default behavior)
- Prevents 422 errors for certificate profiles that don't permit backdated revocation

**Implementation:**
- `backdateRevocation` flag parsed at line 178
- Passed to `revokeCertificate()` method at line 286
- Method conditionally adds `&date=` parameter to URL only when flag is true (lines 729-734)
- Uses `certificate.getNotBefore()` and converts to OffsetDateTime with UTC timezone (line 731)
- `StressTestResult` inner class (lines 117-125) tracks issuance and revocation failures separately

**URL Format:**
```
# Without --backdaterevoke (default)
/revoke?reason=UNSPECIFIED

# With --backdaterevoke
/revoke?reason=UNSPECIFIED&date=2025-12-30T10:30:00Z
```

**Error Prevention:**
Without `--backdaterevoke` (default):
```
Revocation uses current time - works with all certificate profiles
```

With `--backdaterevoke`:
```
Revocation uses certificate's notBefore date - requires certificate profile to allow backdated revocation
Prevents: "Back dated revocation not allowed for certificate profile"
```

---

### 2. Custom Subject DN Support (`--subjectdn`)
**Line References:** 83, 126-127, 147-152, 386-410

Allows specifying a custom Subject DN for certificates instead of using the default `CN=<prefix>_<threadId>_<certId>_<postfix>`.

**Usage:**
```bash
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 --subjectdn "CN=TestUser,O=Keyfactor,C=US"
```

**Behavior:**
- If a CN attribute is present in the provided DN, the prefix, threadId, certId, and postfix are applied to it
- Example: `CN=Test,O=Org` becomes `CN=ErceStressTest__Test_0_0,O=Org` (for first cert)
- Helper method `applyPrefixPostfixToCN()` at lines 474-497 handles the transformation

---

### 3. Subject Alternative Name (SAN) Support (`--san`)
**Line References:** 84, 128-129, 154-159, 389-411, 444-449

Adds Subject Alternative Name extension to certificates with support for DNS names, IP addresses, and other SAN types.

**Usage:**
```bash
# DNS name only
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 --san "dnsName=example.com"

# Multiple SAN values
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 --san "dnsName=example.com,ipAddress=192.168.1.1"
```

**Behavior:**
- DNS names get prefix/postfix applied: `dnsName=example.com` becomes `dnsName=ErceStressTest__example.com_0_0`
- Other SAN types (ipAddress, email, URI) remain unchanged
- Helper method `applyPrefixPostfixToSAN()` at lines 499-523 handles the transformation
- SAN extension added via `generateCertificateRequest()` at lines 444-449

---

### 4. Empty Subject DN with SAN Only
**Line References:** 388-399, 412, 422-423

When only `--san` is provided without `--subjectdn`, the CSR is created with an empty subject DN.

**Usage:**
```bash
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 --san "dnsName=example.com"
```

**Behavior:**
- CSR contains empty subject DN: `new X500Name("")`
- Only the SAN extension is present in the certificate
- Useful for testing SAN-only certificates

---

### 5. Certificate History Testing (`--history`)
**Line References:** 85, 130-131, 161-175, 229, 243-244, 311-325, 364-372, 413-445

Generates multiple certificates per end entity with unique keys to test certificate renewal and history in EJBCA.

**Usage:**
```bash
# Generate 3 certificates per end entity (1 base + 2 additional)
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 --history 2
```

**Behavior:**
- Each end entity receives `1 + historyCount` certificates
- Each certificate uses a **unique key pair** (enforces EJBCA's unique public key requirement)
- All certificates for the same end entity share the **same username and subject DN**
- Total certificates = `numberOfThreads × requestPerThread × (1 + historyCount)`
- Example: 10 threads × 100 certs × 3 = 3000 total certificates for 1000 end entities

**Statistics Output:**
```
Total execution time: 45.2 seconds.
Average issuance time: 0.015 seconds.
Throughput: 66.37 certificates issued per second.
3000 certificates were successfully issued, with 0 failures.
Total end entities: 1000 (3 certificate(s) per entity).
```

---

### 6. Enhanced Error Reporting with CN
**Line References:** 91-92, 255-256, 266, 275, 369, 376, 426, 443, 525-542

Error messages now include the Common Name (CN) from the subject DN to easily identify failed enrollments.

**Before:**
```
Thread ID: 9, Iteration: 9 - Return code was: 400: {"error_code":400,"error_message":"Subject DN field 'ORGANIZATIONALUNIT' must exist."}
```

**After:**
```
Thread ID: 9, Iteration: 9, CN=ErceStressTest__TestUser_9_9 - Return code was: 400: {"error_code":400,"error_message":"Subject DN field 'ORGANIZATIONALUNIT' must exist."}
```

**Implementation:**
- `subjectDns` array stores DN for each certificate (line 92, 376, 443)
- `extractCNForErrorMessage()` method extracts CN from DN (lines 525-542)
- CN info included in error messages at lines 266 and 275

---

## Technical Implementation Details

### Data Structures
```java
private String[][] payloads;      // Line 91 - Stores JSON payloads for each certificate
private String[][] subjectDns;    // Line 92 - Stores subject DNs for error reporting
```

### Key Methods

#### `generatePayloads()` - Lines 362-456
- Calculates total certificates per entity: `certsPerEntity = 1 + historyCount`
- Creates payload arrays sized for history: `requestPerThread × certsPerEntity`
- Nested loop generates multiple certificates per end entity
- Each certificate gets unique key pair (lines 415-421)

#### `generateCertificateRequest()` - Lines 458-472
- Accepts subject DN, key pair, algorithm, and SAN
- Adds SAN extension if provided (lines 444-449)
- Returns PKCS#10 CSR with extensions

#### `applyPrefixPostfixToCN()` - Lines 474-497
- Parses subject DN string
- Finds CN attribute and applies transformations
- Format: `CN=<prefix>_<value>_<threadId>_<certId>_<postfix>`

#### `applyPrefixPostfixToSAN()` - Lines 499-523
- Parses SAN string by comma delimiter
- Applies prefix/postfix only to `dnsName` attributes
- Preserves other SAN types unchanged

#### `extractCNForErrorMessage()` - Lines 525-542
- Extracts CN from subject DN
- Returns formatted string: `, CN=value`
- Returns empty string if no CN found

### Execution Flow
1. **Parameter Parsing** (lines 136-175): Parse CLI arguments including history count
2. **Payload Generation** (line 229): Generate CSRs with unique keys per certificate
3. **Parallel Execution** (lines 246-290): Submit CSRs across threads
4. **Statistics Calculation** (lines 311-325): Calculate success/failure rates with history awareness

---

## Combined Usage Examples

### Example 1: Full Feature Set
```bash
stress --ca "MyCA" \
  --certificateprofile "ENDUSER" \
  --endentityprofile "MyProfile" \
  --threads 5 \
  --certs 50 \
  --subjectdn "CN=User,OU=Engineering,O=Keyfactor,C=US" \
  --san "dnsName=user.example.com,ipAddress=10.0.0.1" \
  --history 4 \
  --prefix "Test" \
  --postfix "v1"
```

**Result:**
- 250 end entities (5 threads × 50 certs)
- 1250 total certificates (250 entities × 5 certs per entity)
- Subject DN: `CN=Test_User_0_0_v1,OU=Engineering,O=Keyfactor,C=US`
- SAN: `dnsName=Test_user.example.com_0_0_v1,ipAddress=10.0.0.1`

### Example 2: SAN-Only Certificates
```bash
stress --ca "MyCA" \
  --certificateprofile "ENDUSER" \
  --endentityprofile "MyProfile" \
  --threads 2 \
  --certs 10 \
  --san "dnsName=api.example.com"
```

**Result:**
- 20 end entities with empty subject DN
- Only SAN extension present
- SAN: `dnsName=ErceStressTest__api.example.com_0_0`

### Example 3: History Testing
```bash
stress --ca "MyCA" \
  --certificateprofile "ENDUSER" \
  --endentityprofile "MyProfile" \
  --threads 10 \
  --certs 100 \
  --history 2
```

**Result:**
- 1000 end entities
- 3000 total certificates (3 per entity)
- Each entity has 3 certificates with unique keys
- Perfect for testing certificate renewal workflows

### Example 4: Revocation Testing
```bash
stress --ca "MyCA" \
  --certificateprofile "ENDUSER" \
  --endentityprofile "MyProfile" \
  --threads 10 \
  --certs 100 \
  --revoke
```

**Result:**
- 1000 certificates issued
- Each certificate is immediately revoked after issuance using current timestamp
- Tests complete certificate lifecycle (issuance + revocation)
- Measures both issuance and revocation throughput
- Statistics separately report issuance success/failures and revocation success/failures

### Example 4a: Backdated Revocation Testing
```bash
stress --ca "MyCA" \
  --certificateprofile "ENDUSER" \
  --endentityprofile "MyProfile" \
  --threads 10 \
  --certs 100 \
  --revoke \
  --backdaterevoke
```

**Result:**
- 1000 certificates issued
- Each certificate is revoked using its notBefore date (backdated revocation)
- Useful for testing certificate profiles that allow backdated revocation
- Prevents 422 errors for profiles that don't allow current-time revocation
- Statistics separately track issuance and revocation operations

**Sample Output:**
```
Total execution time: 56.0 seconds.
40 certificates were successfully issued, with 0 issuance failures.
40 certificates were successfully revoked, with 0 revocation failures.
Total end entities: 10 (4 certificate(s) per entity).
```

---

### 6. Certificate Tracking and Bulk Revocation (`--savecerts` and `--revokefile`)
**Line References:** 108-109, 135-159, 207-210, 264-265, 349-351, 372, 397, 446, 491-494, 816-1001

Enables tracking of all issued certificates and performing mass revocation from a saved certificate list without enrollment.

**Usage - Save certificates during issuance:**
```bash
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 --savecerts issued_certs.txt
```

**Usage - Bulk revocation from saved file:**
```bash
stress --revokefile issued_certs.txt --threads 5
```

**Behavior:**
- `--savecerts <filename>`: Saves serial number and issuer DN of all successfully issued certificates to file
- File format: Simple pipe-delimited format (`serialNumber|issuerDn`)
- Certificate tracking happens for ALL successful issuances, regardless of `--revoke` flag
- `--revokefile <filename>`: Performs bulk revocation from previously saved certificate list
- When `--revokefile` is used, NO enrollment occurs - only revocation
- Bulk revocation uses parallel threads for performance (configurable via `--threads`)
- `--backdaterevoke` can be used with `--revokefile` (uses current time as revocation date)

**Implementation:**
- `CertificateInfo` inner class (lines 135-159) stores serial number and issuer DN
- `toString()` method formats to `serialNumber|issuerDn`
- `fromString()` method parses from file format
- `StressTestResult` modified (line 133) to include `List<CertificateInfo> issuedCertificates`
- Certificate tracking added to issuance loop (lines 397)
- `saveCertificatesToFile()` method (lines 824-838) writes certificates to file
- `loadCertificatesFromFile()` method (lines 843-863) reads certificates from file
- `performBulkRevocation()` method (lines 868-1001) handles bulk revocation mode
- Certificates saved after statistics are printed (lines 491-494)
- Bulk revocation mode check at line 349-351

**File Format Example:**
```
1A2B3C4D5E6F|CN=Test CA,O=Keyfactor,C=US
7G8H9I0J1K2L|CN=Test CA,O=Keyfactor,C=US
3M4N5O6P7Q8R|CN=Test CA,O=Keyfactor,C=US
```

**Statistics Output (Bulk Revocation Mode):**
```
Starting bulk revocation from file: issued_certs.txt
Loaded 1000 certificate(s) for revocation
Using 5 thread(s) for parallel revocation

Weapons free. Fire for effect (revocation only).
Fire mission complete. Weapons hold.

Total execution time: 12.5 seconds.
Average revocation time: 0.0125 seconds.
Throughput: 80.0 certificates revoked per second.
1000 certificates were successfully revoked, with 0 revocation failures.
```

---

### Example 4b: Save Certificates with Immediate Revocation
```bash
stress --ca "MyCA" \
  --certificateprofile "ENDUSER" \
  --endentityprofile "MyProfile" \
  --threads 10 \
  --certs 100 \
  --revoke \
  --savecerts issued_certs.txt
```

**Result:**
- 1000 certificates issued
- Each certificate is immediately revoked after issuance
- Certificate information saved to `issued_certs.txt` for later reference
- Useful for testing complete lifecycle and maintaining audit trail

### Example 4c: Bulk Revocation Only
```bash
stress --revokefile issued_certs.txt --threads 10
```

**Result:**
- No certificates issued (enrollment skipped entirely)
- All certificates from file are revoked in parallel using 10 threads
- Useful for mass revocation scenarios or cleanup after testing
- Can re-run multiple times on the same file (already-revoked certs will show as failures)

---

### Example 5: Combined Features
```bash
stress --ca "MyCA" \
  --certificateprofile "ENDUSER" \
  --endentityprofile "MyProfile" \
  --threads 5 \
  --certs 50 \
  --subjectdn "CN=User,OU=Engineering,O=Keyfactor,C=US" \
  --san "dnsName=user.example.com" \
  --history 2 \
  --revoke \
  --savecerts test_certs.txt
```

**Result:**
- 250 end entities
- 750 total certificates (3 per entity: 1 base + 2 history)
- Each certificate is revoked immediately after issuance
- All certificate information saved to `test_certs.txt`
- Tests complete lifecycle with history, revocation, and certificate tracking

---

### 7. Real-time Progress Updates
Displays live progress updates during stress test execution showing certificate counts, success/failure rates, and throughput.

**Usage:**
```bash
# Default 5-second interval
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100

# Custom 10-second interval
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 --progressinterval 10

# Disable progress updates
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 --progressinterval 0
```

**Behavior:**
- Progress updates display every N seconds (configurable, default 5 seconds)
- Shows current certificate count, successful issuances, failed issuances
- When `--revoke` is used, also shows revocation counts (successful/failed)
- Displays current throughput (certificates per second) based on interval
- Shows progress as `current/expected` with percentage
- Updates are non-blocking and run on a daemon thread
- Works in both normal issuance mode and bulk revocation mode
- Automatically stops when test completes

**Sample Output (Normal Mode):**
```
Weapons free. Fire for effect (enrollment + revocation).

Progress: 834/1000 certs (834 successful, 0 failed) - 83.40 certs/s
Progress: 1000/1000 certs (1000 successful, 0 failed) - 83.00 certs/s

Fire mission complete. Weapons hold.
```

**Sample Output (With Revocation):**
```
Weapons free. Fire for effect (enrollment + revocation).

Progress: 500/1000 certs (500 successful, 0 failed), 500 revoked (500 successful, 0 failed) - 50.00 certs/s
Progress: 1000/1000 certs (1000 successful, 0 failed), 1000 revoked (1000 successful, 0 failed) - 50.00 certs/s

Fire mission complete. Weapons hold.
```

**Sample Output (Bulk Revocation Mode):**
```
Starting bulk revocation from file: issued_certs.txt
Loaded 1000 certificate(s) for revocation

Progress: 450/1000 revocations (450 successful, 0 failed) - 90.00 rev/s
Progress: 1000/1000 revocations (1000 successful, 0 failed) - 90.00 rev/s
```

**Parameters:**
- `--progressinterval <seconds>`: Progress update interval (default: 5 seconds, 0 to disable)

**Implementation:**
- Volatile counters for thread-safe tracking in normal mode: `totalIssuanceAttempts`, `totalSuccessfulIssuances`, `totalFailedIssuances`, `totalSuccessfulRevocations`, `totalFailedRevocations`
- Separate daemon threads for normal mode and bulk revocation mode
- Synchronized blocks ensure thread-safe counter increments
- Progress thread automatically terminates on test completion
- Expected total calculated based on threads, certs per thread, and history count

### 8. CSV/Markdown Output Formats
Export stress test results to CSV or Markdown files for automated testing and reporting.

**Usage:**
```bash
# CSV output for automated testing (normal mode)
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 \
  --outputformat csv --outputfile results.csv

# Markdown output for human-readable reports (normal mode)
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100 --revoke \
  --outputformat markdown --outputfile results.md

# CSV output for bulk revocation mode
stress --revokefile issued_certs.txt --threads 10 \
  --outputformat csv --outputfile revocation_results.csv

# Console output (default, no file created)
stress --ca "MyCA" --certificateprofile "ENDUSER" --endentityprofile "MyProfile" \
  --threads 10 --certs 100
```

**CSV Format (Issuance Mode):**
- Single header row with column names
- Single data row with test results
- Includes timestamp for each test run
- Easy to parse and import into spreadsheets or automated systems
- Columns: Test Duration, Total Certs, Successful Issuances, Failed Issuances, Successful Revocations, Failed Revocations, Throughput, End Entities, Certs per Entity

**Sample CSV (Issuance Mode):**
```csv
Test Duration (s),Total Certs,Successful Issuances,Failed Issuances,Successful Revocations,Failed Revocations,Throughput (certs/s),End Entities,Certs per Entity,Timestamp
45.20,3000,3000,0,3000,0,66.37,1000,3,2025-12-31 14:30:00
```

**CSV Format (Bulk Revocation Mode):**
```csv
Test Duration (s),Total Revocations,Successful,Failed,Throughput (rev/s),Timestamp
12.50,1000,1000,0,80.00,2025-12-31 14:35:00
```

**Markdown Format (Issuance Mode):**
- Human-readable formatted tables
- Includes test configuration, performance metrics, and detailed results
- Perfect for embedding in documentation or sharing with stakeholders
- Includes timestamp and all test parameters
- Shows revocation statistics when `--revoke` is used

**Sample Markdown (Issuance Mode):**
```markdown
# X509 Stress Test Results

**Generated:** 2025-12-31 14:30:00

## Test Configuration

| Parameter | Value |
|-----------|-------|
| CA | MyCA |
| Certificate Profile | ENDUSER |
| End Entity Profile | MyProfile |
| Threads | 10 |
| Certificates per Thread | 100 |
| History Count | 2 |
| Revoke After Issuance | Yes |

## Performance Metrics

| Metric | Value |
|--------|-------|
| Total Execution Time | 45.20 s |
| Average Issuance Time | 0.015 s |
| Throughput | 66.37 certs/s |

## Issuance Results

| Metric | Count |
|--------|-------|
| Successful Issuances | 3000 |
| Failed Issuances | 0 |
| Total End Entities | 1000 |
| Certificates per Entity | 3 |

## Revocation Results

| Metric | Count |
|--------|-------|
| Successful Revocations | 3000 |
| Failed Revocations | 0 |
```

**Markdown Format (Bulk Revocation Mode):**
```markdown
# Bulk Revocation Results

**Generated:** 2025-12-31 14:35:00

## Test Configuration

| Parameter | Value |
|-----------|-------|
| Revocation File | issued_certs.txt |
| Threads | 10 |

## Performance Metrics

| Metric | Value |
|--------|-------|
| Total Execution Time | 12.50 s |
| Average Revocation Time | 0.0125 s |
| Throughput | 80.00 rev/s |

## Revocation Results

| Metric | Count |
|--------|-------|
| Total Revocations | 1000 |
| Successful | 1000 |
| Failed | 0 |
```

**Parameters:**
- `--outputformat <format>`: Output format - 'console' (default), 'csv', or 'markdown'
- `--outputfile <filename>`: File path to save results (required when format is csv or markdown)

**Implementation:**
- `writeIssuanceResultsToCsv()` method generates CSV output for issuance mode
- `writeIssuanceResultsToMarkdown()` method generates Markdown output for issuance mode
- `writeRevocationResultsToCsv()` method generates CSV output for bulk revocation mode
- `writeRevocationResultsToMarkdown()` method generates Markdown output for bulk revocation mode
- Both normal and bulk revocation modes support CSV and Markdown output
- All methods use try-with-resources for safe file handling
- Validation ensures output file is specified when format requires it
- All statistics from console output are included in file outputs

---

## Code Organization

### Imports (Lines 15-18, 41-49)
File I/O for certificate tracking:
- `java.io.BufferedReader`, `BufferedWriter`, `FileReader`, `FileWriter`

BouncyCastle ASN.1 classes for SAN extension support:
- `ASN1EncodableVector`, `DERSequence`, `DERSet`
- `Extension`, `Extensions`, `ExtensionsGenerator`
- `GeneralNames`

### Constants (Lines 78-85, 108-109)
All CLI argument definitions including:
- `SAVECERTS_ARG = "--savecerts"`
- `REVOKEFILE_ARG = "--revokefile"`

### Inner Classes (Lines 123-159)
- `StressTestResult` (lines 123-133): Aggregates issuance failures, revocation failures, and issued certificates
- `CertificateInfo` (lines 135-159): Stores and serializes certificate serial number and issuer DN

### Helper Methods (Lines 474-542, 816-863)
- `applyPrefixPostfixToCN()` (lines 474-497)
- `applyPrefixPostfixToSAN()` (lines 499-523)
- `extractCNForErrorMessage()` (lines 525-542)
- `saveCertificatesToFile()` (lines 824-838)
- `loadCertificatesFromFile()` (lines 843-863)
- `performBulkRevocation()` (lines 868-1001)

### Main Logic (Lines 362-456)
Payload generation with history support

---

## Build Status
✅ **All features compile successfully with Gradle**

```bash
BUILD SUCCESSFUL in 7s
4 actionable tasks: 2 executed, 2 up-to-date
```
